### PR TITLE
ci: Update _build_container to log into Azure 

### DIFF
--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -306,10 +306,10 @@ jobs:
           set -e
 
           if [[ $EXISTS -eq 0 ]]; then
-            echo "Image $FULL_IMAGE_TAG exists in ACR. Skipping build."
+            echo "Image $IMAGE_TAG exists in ACR. Skipping build."
             echo "skip-build=true" >> $GITHUB_OUTPUT
           else
-            echo "Image $FULL_IMAGE_TAG does not exist in ACR. Proceeding with build."
+            echo "Image $IMAGE_TAG does not exist in ACR. Proceeding with build."
             echo "skip-build=false" >> $GITHUB_OUTPUT
           fi
 
@@ -330,11 +330,11 @@ jobs:
           pull: ${{ !inputs.use-cache }}
           context: ${{ github.run_id }}/
 
-    - name: Set container_uri
-      id: set_container_uri
-      run: |
-        if [[ -n "$IMAGE_TAG" ]]; then
-          echo "container_uri=nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
-        else
-          echo "container_uri=nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID" >> $GITHUB_OUTPUT
-        fi
+      - name: Set container_uri
+        id: set_container_uri
+        run: |
+          if [[ -n "$IMAGE_TAG" ]]; then
+            echo "container_uri=nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
+          else
+            echo "container_uri=nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID" >> $GITHUB_OUTPUT
+          fi

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -61,6 +61,21 @@ on:
         type: string
         description: "Cache from"
         default: ""
+      azure-client-id:
+        required: false
+        type: string
+        description: "Azure client ID"
+        default: ""
+      azure-subscription-id:
+        required: false
+        type: string
+        description: "Azure subscription ID"
+        default: ""
+      azure-tenant-id:
+        required: false
+        type: string
+        description: "Azure tenant ID"
+        default: ""
     outputs:
       container-uri:
         description: URI of container
@@ -69,6 +84,10 @@ on:
 defaults:
   run:
     shell: bash -x -e -u -o pipefail {0}
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   main:
@@ -79,6 +98,24 @@ jobs:
       GH_REF: ${{ github.ref }}
       RUN_ID: ${{ github.run_id }}
     steps:
+      - name: Install Azure CLI
+        if: ${{ inputs.azure-client-id != '' }}
+        run: |
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+
+      - name: Azure Login
+        if: ${{ inputs.azure-client-id != '' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Azure ACR Login
+        if: ${{ inputs.azure-client-id != '' }}
+        run: |
+          az acr login --name nemoci
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -114,7 +151,7 @@ jobs:
             TAGS="\
             nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID
             nemoci.azurecr.io/$IMAGE_NAME:main"
-            
+
             echo "TAGS<<EOF" >> $GITHUB_ENV
             echo "$TAGS" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
@@ -126,7 +163,7 @@ jobs:
               echo "${TAGS}" >> $GITHUB_ENV
             fi
             echo "EOF" >> $GITHUB_ENV
-            
+
             echo "CACHE_TO=type=inline" >> $GITHUB_ENV
 
           elif [[ -n "$PR_NUMBER" ]]; then
@@ -144,7 +181,7 @@ jobs:
             nemoci.azurecr.io/$IMAGE_NAME:main
             nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID
             nemoci.azurecr.io/$IMAGE_NAME:$PR_NUMBER"
-            
+
             echo "CACHE_FROM<<EOF" >> $GITHUB_ENV
             if [[ -n "${{ inputs.cache-from }}" ]]; then
               echo "${{ inputs.cache-from }}" >> $GITHUB_ENV
@@ -160,7 +197,7 @@ jobs:
 
             TAGS="\
             nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID"
-            
+
             echo "TAGS<<EOF" >> $GITHUB_ENV
             echo "$TAGS" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
@@ -201,7 +238,7 @@ jobs:
               echo "${CACHE_FROM}" >> $GITHUB_ENV
             fi
             echo "EOF" >> $GITHUB_ENV
-            
+
             CACHE_TO="\
             type=registry,ref=nemoci.azurecr.io/$IMAGE_NAME-buildcache:main,mode=max"
             echo "CACHE_TO<<EOF" >> $GITHUB_ENV
@@ -212,7 +249,7 @@ jobs:
             TAGS="\
             nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID
             nemoci.azurecr.io/$IMAGE_NAME:$PR_NUMBER"
-            
+
             echo "TAGS<<EOF" >> $GITHUB_ENV
             echo "$TAGS" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
@@ -227,7 +264,7 @@ jobs:
               echo "${CACHE_FROM}" >> $GITHUB_ENV
             fi
             echo "EOF" >> $GITHUB_ENV
-            
+
             CACHE_TO="\
             type=registry,ref=nemoci.azurecr.io/$IMAGE_NAME-buildcache:$PR_NUMBER,mode=max"
             echo "CACHE_TO<<EOF" >> $GITHUB_ENV
@@ -237,7 +274,7 @@ jobs:
           else
             TAGS="\
             nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID"
-            
+
             echo "TAGS<<EOF" >> $GITHUB_ENV
             echo "$TAGS" >> $GITHUB_ENV
             echo "EOF" >> $GITHUB_ENV
@@ -251,7 +288,7 @@ jobs:
               echo "${CACHE_FROM}" >> $GITHUB_ENV
             fi
             echo "EOF" >> $GITHUB_ENV
-            
+
             CACHE_TO=""
             echo "CACHE_TO<<EOF" >> $GITHUB_ENV
             echo "$CACHE_TO" >> $GITHUB_ENV

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -66,16 +66,6 @@ on:
         description: "Whether to use Azure credentials to login to ACR"
         type: boolean
         default: false
-      skip-build-if-exists:
-        required: false
-        description: "Whether to skip the build and push of the image if it already exists via the full-image-tag"
-        type: boolean
-        default: false
-      image-tag:
-        required: false
-        description: "The image tag to use. Otherwise, this is generated using the run id"
-        type: string
-        default: ""
     secrets:
       AZURE_CLIENT_ID:
         required: false
@@ -83,6 +73,10 @@ on:
         required: false
       AZURE_SUBSCRIPTION_ID:
         required: false
+    outputs:
+      container-uri:
+        description: URI of container
+        value: nemoci.azurecr.io/${{ inputs.image-name }}:${{ github.run_id }}
 
 defaults:
   run:
@@ -150,9 +144,7 @@ jobs:
             echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
           fi
 
-          if [[ -n "$IMAGE_TAG" ]]; then
-            echo "TAGS=nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG" >> $GITHUB_ENV
-          elif [[ "$GH_REF" == "refs/heads/main" ]]; then
+          if [[ "$GH_REF" == "refs/heads/main" ]]; then
             TAGS="\
             nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID
             nemoci.azurecr.io/$IMAGE_NAME:main"
@@ -293,26 +285,7 @@ jobs:
 
           fi
 
-      - name: Check if build can be skipped
-        id: check_skip_build
-        if: ${{ inputs.skip-build-if-exists && inputs.image-tag != '' && inputs.has-azure-credentials }}
-        run: |
-          # Query ACR for the tag
-          set +e
-          az acr repository show-manifests --name nemoci --repository "$IMAGE_NAME" --query "[?tags[?@=='$IMAGE_TAG']]" | grep -q "$IMAGE_TAG"
-          EXISTS=$?
-          set -e
-
-          if [[ $EXISTS -eq 0 ]]; then
-            echo "Image $IMAGE_TAG exists in ACR. Skipping build."
-            echo "skip-build=true" >> $GITHUB_OUTPUT
-          else
-            echo "Image $IMAGE_TAG does not exist in ACR. Proceeding with build."
-            echo "skip-build=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Build and push
-        if: ${{ steps.check_skip_build.outputs.skip-build != 'true' }}
         uses: docker/build-push-action@v5
         with:
           file: ${{ github.run_id }}/${{ inputs.dockerfile }}
@@ -327,12 +300,3 @@ jobs:
             ${{ env.TAGS }}
           pull: ${{ !inputs.use-cache }}
           context: ${{ github.run_id }}/
-
-      - name: Set container_uri
-        id: set_container_uri
-        run: |
-          if [[ -n "$IMAGE_TAG" ]]; then
-            echo "container_uri=nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
-          else
-            echo "container_uri=nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID" >> $GITHUB_OUTPUT
-          fi

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -139,10 +139,16 @@ jobs:
         run: |
           echo "CACHE_FROM=" >> $GITHUB_ENV
 
+      - name: Set PR_NUMBER from branch if needed
+        run: |
+          if [[ -z "$PR_NUMBER" && "$GH_REF" =~ refs/heads/pull_request/([0-9]+) ]]; then
+            export PR_NUMBER="${BASH_REMATCH[1]}"
+            echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          fi
+
       - name: Configure inline cache
         if: ${{ inputs.use-cache == true && inputs.use-inline-cache == true }}
         run: |
-
           if [[ "$GH_REF" == "refs/heads/main" ]]; then
             docker pull nemoci.azurecr.io/$IMAGE_NAME:main || true
 

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -183,13 +183,7 @@ jobs:
         if: ${{ inputs.use-cache == true && inputs.use-inline-cache == true }}
         run: |
 
-          if [[ -n "$IMAGE_TAG" ]]; then
-
-            docker pull nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG || true
-            echo "CACHE_FROM=nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG" >> $GITHUB_ENV
-            echo "CACHE_TO=type=inline" >> $GITHUB_ENV
-
-          elif [[ "$GH_REF" == "refs/heads/main" ]]; then
+          if [[ "$GH_REF" == "refs/heads/main" ]]; then
             docker pull nemoci.azurecr.io/$IMAGE_NAME:main || true
 
             echo "CACHE_FROM<<EOF" >> $GITHUB_ENV
@@ -243,12 +237,7 @@ jobs:
       - name: Configure registry cache
         if: ${{ inputs.use-cache == true && inputs.use-inline-cache == false }}
         run: |
-          if [[ -n "$IMAGE_TAG" ]]; then
-
-            echo "CACHE_FROM=nemoci.azurecr.io/$IMAGE_NAME-buildcache:$IMAGE_TAG" >> $GITHUB_ENV
-            echo "CACHE_TO=type=registry,ref=nemoci.azurecr.io/$IMAGE_NAME-buildcache:$IMAGE_TAG,mode=max" >> $GITHUB_ENV
-
-          elif [[ "$GH_REF" == "refs/heads/main" ]]; then
+          if [[ "$GH_REF" == "refs/heads/main" ]]; then
 
             CACHE_FROM="\
             nemoci.azurecr.io/$IMAGE_NAME-buildcache:main"

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -83,10 +83,6 @@ on:
         required: false
       AZURE_SUBSCRIPTION_ID:
         required: false
-    outputs:
-      container-uri:
-        description: URI of container
-        value: ${{ steps.set_container_uri.outputs.container_uri }}
 
 defaults:
   run:
@@ -106,6 +102,8 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
       GH_REF: ${{ github.ref }}
       RUN_ID: ${{ github.run_id }}
+    outputs:
+      container-uri: ${{ steps.set_container_uri.outputs.container_uri }}
     steps:
       - name: Install Azure CLI
         if: ${{ inputs.has-azure-credentials }}
@@ -184,7 +182,7 @@ jobs:
       - name: Configure inline cache
         if: ${{ inputs.use-cache == true && inputs.use-inline-cache == true }}
         run: |
-          
+
           if [[ -n "$IMAGE_TAG" ]]; then
 
             docker pull nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG || true

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -61,20 +61,21 @@ on:
         type: string
         description: "Cache from"
         default: ""
-      azure-client-id:
+    secrets:
+      AZURE_CLIENT_ID:
         required: false
         type: string
         description: "Azure client ID"
         default: ""
-      azure-subscription-id:
-        required: false
-        type: string
-        description: "Azure subscription ID"
-        default: ""
-      azure-tenant-id:
+      AZURE_TENANT_ID:
         required: false
         type: string
         description: "Azure tenant ID"
+        default: ""
+      AZURE_SUBSCRIPTION_ID:
+        required: false
+        type: string
+        description: "Azure subscription ID"
         default: ""
     outputs:
       container-uri:
@@ -99,12 +100,12 @@ jobs:
       RUN_ID: ${{ github.run_id }}
     steps:
       - name: Install Azure CLI
-        if: ${{ inputs.azure-client-id != '' }}
+        if: ${{ secrets.AZURE_CLIENT_ID != '' }}
         run: |
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
       - name: Azure Login
-        if: ${{ inputs.azure-client-id != '' }}
+        if: ${{ secrets.AZURE_CLIENT_ID != '' }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -112,7 +113,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Azure ACR Login
-        if: ${{ inputs.azure-client-id != '' }}
+        if: ${{ secrets.AZURE_CLIENT_ID != '' }}
         run: |
           az acr login --name nemoci
 

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -184,8 +184,14 @@ jobs:
       - name: Configure inline cache
         if: ${{ inputs.use-cache == true && inputs.use-inline-cache == true }}
         run: |
+          
+          if [[ -n "$IMAGE_TAG" ]]; then
 
-          if [[ "$GH_REF" == "refs/heads/main" ]]; then
+            docker pull nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG || true
+            echo "CACHE_FROM=nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG" >> $GITHUB_ENV
+            echo "CACHE_TO=type=inline" >> $GITHUB_ENV
+
+          elif [[ "$GH_REF" == "refs/heads/main" ]]; then
             docker pull nemoci.azurecr.io/$IMAGE_NAME:main || true
 
             echo "CACHE_FROM<<EOF" >> $GITHUB_ENV
@@ -239,7 +245,12 @@ jobs:
       - name: Configure registry cache
         if: ${{ inputs.use-cache == true && inputs.use-inline-cache == false }}
         run: |
-          if [[ "$GH_REF" == "refs/heads/main" ]]; then
+          if [[ -n "$IMAGE_TAG" ]]; then
+
+            echo "CACHE_FROM=nemoci.azurecr.io/$IMAGE_NAME-buildcache:$IMAGE_TAG" >> $GITHUB_ENV
+            echo "CACHE_TO=type=registry,ref=nemoci.azurecr.io/$IMAGE_NAME-buildcache:$IMAGE_TAG,mode=max" >> $GITHUB_ENV
+
+          elif [[ "$GH_REF" == "refs/heads/main" ]]; then
 
             CACHE_FROM="\
             nemoci.azurecr.io/$IMAGE_NAME-buildcache:main"

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -139,16 +139,14 @@ jobs:
         run: |
           echo "CACHE_FROM=" >> $GITHUB_ENV
 
-      - name: Set PR_NUMBER from branch if needed
-        run: |
-          if [[ -z "$PR_NUMBER" && "$GH_REF" =~ refs/heads/pull_request/([0-9]+) ]]; then
-            export PR_NUMBER="${BASH_REMATCH[1]}"
-            echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-          fi
-
       - name: Configure inline cache
         if: ${{ inputs.use-cache == true && inputs.use-inline-cache == true }}
         run: |
+          if [[ -z "$PR_NUMBER" && "$GH_REF" =~ refs/heads/pull-request/([0-9]+) ]]; then
+            export PR_NUMBER="${BASH_REMATCH[1]}"
+            echo $PR_NUMBER
+          fi
+
           if [[ "$GH_REF" == "refs/heads/main" ]]; then
             docker pull nemoci.azurecr.io/$IMAGE_NAME:main || true
 
@@ -225,6 +223,11 @@ jobs:
       - name: Configure registry cache
         if: ${{ inputs.use-cache == true && inputs.use-inline-cache == false }}
         run: |
+          if [[ -z "$PR_NUMBER" && "$GH_REF" =~ refs/heads/pull-request/([0-9]+) ]]; then
+            export PR_NUMBER="${BASH_REMATCH[1]}"
+            echo $PR_NUMBER
+          fi
+
           if [[ "$GH_REF" == "refs/heads/main" ]]; then
             TAGS="\
             nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -66,6 +66,16 @@ on:
         description: "Whether to use Azure credentials to login to ACR"
         type: boolean
         default: false
+      skip-build-if-exists:
+        required: false
+        description: "Whether to skip the build and push of the image if it already exists via the full-image-tag"
+        type: boolean
+        default: false
+      image-tag:
+        required: false
+        description: "The image tag to use. Otherwise, this is generated using the run id"
+        type: string
+        default: ""
     secrets:
       AZURE_CLIENT_ID:
         required: false
@@ -76,7 +86,7 @@ on:
     outputs:
       container-uri:
         description: URI of container
-        value: nemoci.azurecr.io/${{ inputs.image-name }}:${{ github.run_id }}
+        value: ${{ steps.set_container_uri.outputs.container_uri }}
 
 defaults:
   run:
@@ -92,6 +102,7 @@ jobs:
     environment: nemo-ci
     env:
       IMAGE_NAME: ${{ inputs.image-name }}
+      IMAGE_TAG: ${{ inputs.image-tag }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       GH_REF: ${{ github.ref }}
       RUN_ID: ${{ github.run_id }}
@@ -134,6 +145,37 @@ jobs:
           # trivial (non-multi-stage) builds.
           driver: ${{ inputs.use-inline-cache == true && 'docker' || 'docker-container' }}
 
+      - name: Set TAGS and PR_NUMBER
+        run: |
+          if [[ -z "$PR_NUMBER" && "$GH_REF" =~ refs/heads/pull-request/([0-9]+) ]]; then
+            export PR_NUMBER="${BASH_REMATCH[1]}"
+            echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          fi
+
+          if [[ -n "$IMAGE_TAG" ]]; then
+            echo "TAGS=nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG" >> $GITHUB_ENV
+          elif [[ "$GH_REF" == "refs/heads/main" ]]; then
+            TAGS="\
+            nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID
+            nemoci.azurecr.io/$IMAGE_NAME:main"
+            echo "TAGS<<EOF" >> $GITHUB_ENV
+            echo "$TAGS" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          elif [[ -n "$PR_NUMBER" ]]; then
+            TAGS="\
+            nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID
+            nemoci.azurecr.io/$IMAGE_NAME:$PR_NUMBER"
+            echo "TAGS<<EOF" >> $GITHUB_ENV
+            echo "$TAGS" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          else
+            TAGS="\
+            nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID"
+            echo "TAGS<<EOF" >> $GITHUB_ENV
+            echo "$TAGS" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+          fi
+
       - name: No cache
         if: ${{ inputs.use-cache == false }}
         run: |
@@ -142,21 +184,9 @@ jobs:
       - name: Configure inline cache
         if: ${{ inputs.use-cache == true && inputs.use-inline-cache == true }}
         run: |
-          if [[ -z "$PR_NUMBER" && "$GH_REF" =~ refs/heads/pull-request/([0-9]+) ]]; then
-            export PR_NUMBER="${BASH_REMATCH[1]}"
-            echo $PR_NUMBER
-          fi
 
           if [[ "$GH_REF" == "refs/heads/main" ]]; then
             docker pull nemoci.azurecr.io/$IMAGE_NAME:main || true
-
-            TAGS="\
-            nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID
-            nemoci.azurecr.io/$IMAGE_NAME:main"
-
-            echo "TAGS<<EOF" >> $GITHUB_ENV
-            echo "$TAGS" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
 
             echo "CACHE_FROM<<EOF" >> $GITHUB_ENV
             if [[ -n "${{ inputs.cache-from }}" ]]; then
@@ -171,13 +201,6 @@ jobs:
           elif [[ -n "$PR_NUMBER" ]]; then
             docker pull nemoci.azurecr.io/$IMAGE_NAME:main || true
             docker pull nemoci.azurecr.io/$IMAGE_NAME:$PR_NUMBER || true
-
-            TAGS="\
-            nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID
-            nemoci.azurecr.io/$IMAGE_NAME:$PR_NUMBER"
-            echo "TAGS<<EOF" >> $GITHUB_ENV
-            echo "$TAGS" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
 
             CACHE_FROM="\
             nemoci.azurecr.io/$IMAGE_NAME:main
@@ -196,13 +219,6 @@ jobs:
 
           else
             docker pull nemoci.azurecr.io/$IMAGE_NAME:main || true
-
-            TAGS="\
-            nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID"
-
-            echo "TAGS<<EOF" >> $GITHUB_ENV
-            echo "$TAGS" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
 
             CACHE_FROM="\
             nemoci.azurecr.io/$IMAGE_NAME:main
@@ -223,18 +239,7 @@ jobs:
       - name: Configure registry cache
         if: ${{ inputs.use-cache == true && inputs.use-inline-cache == false }}
         run: |
-          if [[ -z "$PR_NUMBER" && "$GH_REF" =~ refs/heads/pull-request/([0-9]+) ]]; then
-            export PR_NUMBER="${BASH_REMATCH[1]}"
-            echo $PR_NUMBER
-          fi
-
           if [[ "$GH_REF" == "refs/heads/main" ]]; then
-            TAGS="\
-            nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID
-            nemoci.azurecr.io/$IMAGE_NAME:main"
-            echo "TAGS<<EOF" >> $GITHUB_ENV
-            echo "$TAGS" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
 
             CACHE_FROM="\
             nemoci.azurecr.io/$IMAGE_NAME-buildcache:main"
@@ -253,13 +258,6 @@ jobs:
             echo "EOF" >> $GITHUB_ENV
 
           elif [[ -n "$PR_NUMBER" ]]; then
-            TAGS="\
-            nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID
-            nemoci.azurecr.io/$IMAGE_NAME:$PR_NUMBER"
-
-            echo "TAGS<<EOF" >> $GITHUB_ENV
-            echo "$TAGS" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
 
             CACHE_FROM="\
             nemoci.azurecr.io/$IMAGE_NAME-buildcache:main
@@ -279,12 +277,6 @@ jobs:
             echo "EOF" >> $GITHUB_ENV
 
           else
-            TAGS="\
-            nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID"
-
-            echo "TAGS<<EOF" >> $GITHUB_ENV
-            echo "$TAGS" >> $GITHUB_ENV
-            echo "EOF" >> $GITHUB_ENV
 
             CACHE_FROM="\
             nemoci.azurecr.io/$IMAGE_NAME-buildcache:main"
@@ -303,7 +295,26 @@ jobs:
 
           fi
 
+      - name: Check if build can be skipped
+        id: check_skip_build
+        if: ${{ inputs.skip-build-if-exists && inputs.image-tag != '' && inputs.has-azure-credentials }}
+        run: |
+          # Query ACR for the tag
+          set +e
+          az acr repository show-manifests --name nemoci --repository "$IMAGE_NAME" --query "[?tags[?@=='$IMAGE_TAG']]" | grep -q "$IMAGE_TAG"
+          EXISTS=$?
+          set -e
+
+          if [[ $EXISTS -eq 0 ]]; then
+            echo "Image $FULL_IMAGE_TAG exists in ACR. Skipping build."
+            echo "skip-build=true" >> $GITHUB_OUTPUT
+          else
+            echo "Image $FULL_IMAGE_TAG does not exist in ACR. Proceeding with build."
+            echo "skip-build=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build and push
+        if: ${{ steps.check_skip_build.outputs.skip-build != 'true' }}
         uses: docker/build-push-action@v5
         with:
           file: ${{ github.run_id }}/${{ inputs.dockerfile }}
@@ -318,3 +329,12 @@ jobs:
             ${{ env.TAGS }}
           pull: ${{ !inputs.use-cache }}
           context: ${{ github.run_id }}/
+
+    - name: Set container_uri
+      id: set_container_uri
+      run: |
+        if [[ -n "$IMAGE_TAG" ]]; then
+          echo "container_uri=nemoci.azurecr.io/$IMAGE_NAME:$IMAGE_TAG" >> $GITHUB_OUTPUT
+        else
+          echo "container_uri=nemoci.azurecr.io/$IMAGE_NAME:$RUN_ID" >> $GITHUB_OUTPUT
+        fi

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -61,6 +61,11 @@ on:
         type: string
         description: "Cache from"
         default: ""
+      has-azure-credentials:
+        required: false
+        description: "Whether to use Azure credentials to login to ACR"
+        type: boolean
+        default: false
     secrets:
       AZURE_CLIENT_ID:
         required: false
@@ -91,12 +96,12 @@ jobs:
       RUN_ID: ${{ github.run_id }}
     steps:
       - name: Install Azure CLI
-        if: ${{ secrets.AZURE_CLIENT_ID != '' }}
+        if: ${{ inputs.has-azure-credentials }}
         run: |
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
       - name: Azure Login
-        if: ${{ secrets.AZURE_CLIENT_ID != '' }}
+        if: ${{ inputs.has-azure-credentials }}
         uses: azure/login@v2
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -104,7 +109,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Azure ACR Login
-        if: ${{ secrets.AZURE_CLIENT_ID != '' }}
+        if: ${{ inputs.has-azure-credentials }}
         run: |
           az acr login --name nemoci
 

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -92,12 +92,9 @@ jobs:
     environment: nemo-ci
     env:
       IMAGE_NAME: ${{ inputs.image-name }}
-      IMAGE_TAG: ${{ inputs.image-tag }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       GH_REF: ${{ github.ref }}
       RUN_ID: ${{ github.run_id }}
-    outputs:
-      container-uri: ${{ steps.set_container_uri.outputs.container_uri }}
     steps:
       - name: Install Azure CLI
         if: ${{ inputs.has-azure-credentials }}

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -89,6 +89,7 @@ permissions:
 jobs:
   main:
     runs-on: ${{ inputs.runner }}
+    environment: nemo-ci
     env:
       IMAGE_NAME: ${{ inputs.image-name }}
       PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -64,19 +64,10 @@ on:
     secrets:
       AZURE_CLIENT_ID:
         required: false
-        type: string
-        description: "Azure client ID"
-        default: ""
       AZURE_TENANT_ID:
         required: false
-        type: string
-        description: "Azure tenant ID"
-        default: ""
       AZURE_SUBSCRIPTION_ID:
         required: false
-        type: string
-        description: "Azure subscription ID"
-        default: ""
     outputs:
       container-uri:
         description: URI of container


### PR DESCRIPTION
Update _build_container to log into Azure and optionally skip building if image exists

On non-Azure machines, we can optionally pass Azure credentials to allow the Github action to assume an Azure role with permissions to pull and push to the ACR. 

Also, this optionally will allow the caller to pass an image tag explicitly instead of using the run id. This might be a hash of some dependency file for example such as pyproject.toml and Dockerfile. Then we can also optionally skip a build by checking if the image tag already exists. This is intended for non-Azure machines so that we do not unnecessarily attempt building an image as long as dependencies have not changed.