### PR TITLE
feat: Update cherry-pick to use "cp" to pass the semantic PR check

### DIFF
--- a/.github/workflows/_cherry_pick.yml
+++ b/.github/workflows/_cherry_pick.yml
@@ -103,7 +103,7 @@ jobs:
               PAYLOAD=$(jq \
                 -n \
                 -c \
-                --arg TITLE "cherry-pick: \`$PR_TITLE ($PR_ID)\` into \`$RELEASE_BRANCH\`" \
+                --arg TITLE "cp: \`$PR_TITLE ($PR_ID)\` into \`$RELEASE_BRANCH\`" \
                 --arg HEAD "cherry-pick-$PR_ID-$RELEASE_BRANCH" \
                 --arg RELEASE_BRANCH "$RELEASE_BRANCH" \
                 --arg BODY "beep boop [🤖]: $MESSAGE" \

--- a/.github/workflows/_cherry_pick.yml
+++ b/.github/workflows/_cherry_pick.yml
@@ -103,7 +103,7 @@ jobs:
               PAYLOAD=$(jq \
                 -n \
                 -c \
-                --arg TITLE "Cherry pick \`$PR_TITLE ($PR_ID)\` into \`$RELEASE_BRANCH\`" \
+                --arg TITLE "cherry-pick: \`$PR_TITLE ($PR_ID)\` into \`$RELEASE_BRANCH\`" \
                 --arg HEAD "cherry-pick-$PR_ID-$RELEASE_BRANCH" \
                 --arg RELEASE_BRANCH "$RELEASE_BRANCH" \
                 --arg BODY "beep boop [🤖]: $MESSAGE" \

--- a/.github/workflows/_semantic_pull_request.yml
+++ b/.github/workflows/_semantic_pull_request.yml
@@ -37,6 +37,7 @@ jobs:
             ci
             chore
             revert
+            cherry-pick
 
       - name: PR title length
         if: always()

--- a/.github/workflows/_semantic_pull_request.yml
+++ b/.github/workflows/_semantic_pull_request.yml
@@ -37,7 +37,7 @@ jobs:
             ci
             chore
             revert
-            cherry-pick
+            cp
 
       - name: PR title length
         if: always()


### PR DESCRIPTION
feat: Update cherry-pick to use "cp" to pass the semantic PR check

"cp" isn't a known type but at least we can get this passing for repos that use the semantic PR title check.