### PR TITLE
feat: Update release_library workflow to have create-gh-release be optional

### DIFF
--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -49,6 +49,11 @@ on:
         description: "Packaging tool (supported: setuptools, hatch, uv)"
         type: string
         default: setuptools
+      create-gh-release:
+        required: false
+        description: Create a GitHub release
+        type: boolean
+        default: true
     secrets:
       TWINE_USERNAME:
         required: true
@@ -80,6 +85,7 @@ jobs:
     needs: [build-test-publish-wheel]
     runs-on: ubuntu-latest
     environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
+    if: ${{ inputs.create-gh-release == true }}
     outputs:
       is-prerelease: ${{ steps.version-number.outputs.is-prerelease }}
     env:


### PR DESCRIPTION
Update release_library workflow to have create-gh-release be optional

In some cases, the Github Release has already been done but we need to just release the pypi package.