### PR TITLE
fix: Improvements to the auto-release-bot

### DIFF
--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -177,9 +177,17 @@ jobs:
           PATCH=$(cat ${{ inputs.python-package }}/package_info.py | awk '/^PATCH = /' | awk -F"= " '{print $2}')
           PRERELEASE=$(cat ${{ inputs.python-package }}/package_info.py | awk '/^PRE_RELEASE = /' | awk -F"= " '{print $2}' | tr -d '"' | tr -d "'")
 
-          if [[ "$PRERELEASE" != "" ]]; then
-            NEXT_PATCH=$PATCH
-            NEXT_PRERELEASE=rc$((${PRERELEASE#rc} + 1))
+          if [[ "$PRERELEASE" != "" ]]; then            
+            if [[ "$PRERELEASE" == *rc* ]]; then
+              NEXT_PATCH=$PATCH
+              NEXT_PRERELEASE=rc$((${PRERELEASE#rc} + 1))
+            elif [[ "$PRERELEASE" == *a* ]]; then
+              NEXT_PATCH=$PATCH
+              NEXT_PRERELEASE=a$((${PRERELEASE#a} + 1))
+            else
+              echo "Unknown pre-release: $PRERELEASE"
+              exit 1
+            fi
           else
             NEXT_PATCH=$((${PATCH} + 1))
             NEXT_PRERELEASE=$PRERELEASE


### PR DESCRIPTION
A few learnings that the testing didn't show:

* In the first version, I attempted to `gh merge --auto` the bump PR. I thought this would work since (1) all status checks satisfied and (2) bot is able to bypass PRs. However, the PR still needed approvals that prevented the auto-merge.
* I learned that we still need to manually merge the commit by running `git checkout main && git merge deployment-branch && git push`
* Why open a PR if we're still going to manually merge it? Some checks like DCO only run on PRs, not on commits. If we don't open a PR, the commit will not have the DCO check and so not all required status checks are satisfied. We could mock DCO too, but going via a PR seems more future proof. 

Let me summarize everything:

* We create the version check commit and push it to a protected branch. 
* Only `nemo-automation-bot` can push to these branches
* On these branches, all compute heavy status checks are mocked by no-ops 
* We open a PR of this branch to also collect app-based status checks
* We wait for all status checks on this commit to complete
* Afterwards we attempt to merge the commit and delete the branch

I also decided that we should merge this bump commit before releasing anything. We want to avoid an in-flight conflict of some engineer pushing into main while our workflow is running. Better to "lock" the version file before release anything.

Finally: When this workflow runs in "live" mode (dry-run: false), I added a sanity check that still performs the dry-run before starting with the release workflow. I like this because it's another safe-guard to sanity test build/test/publish before proceeding with a push to main.

Tested this successfully by pushing nemo-export-deploy 0.1.1 to pypi prod.