### PR TITLE
fix: Tolerate more commas than email addresses for docs publish

### DIFF
--- a/.github/actions/publish-docs/action.yml
+++ b/.github/actions/publish-docs/action.yml
@@ -290,7 +290,7 @@ runs:
         cat /tmp/flush.xml
 
         # Validate and prepare email list JSON
-        echo -n "${{ inputs.emails-csv }}" | jq -Rc 'split(",")' > /tmp/email-addresses.json || {
+        echo -n "${{ inputs.emails-csv }}" | jq -Rc 'split(",") | map(select(length > 0))' > /tmp/email-addresses.json || {
           echo "::error::Invalid JSON format for Akamai notification emails"
           exit 1
         }


### PR DESCRIPTION
In some pipelines, the email addresses end up being like ",me@blah.com".  Ignore empty email addresses.

https://github.com/NVIDIA-NeMo/Automodel/actions/runs/21763947912/job/62794714405