### PR TITLE
fix: set NO_VCS_VERSION=1 in wheel build step

### DIFF
--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -165,6 +165,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           SRC_DIR: ${{ inputs.has-src-dir && 'src/' || '' }}
           NO_BUILD_ISOLATION: ${{ inputs.no-build-isolation }}
+          NO_VCS_VERSION: "1"
         run: |
           cd ${{ github.run_id }}
           cd $ROOTDIR


### PR DESCRIPTION
## Summary

- Sets `NO_VCS_VERSION=1` in the env of the "Build wheel" step

## Why

When a repo's `package_info.py` appends `+<short-sha>` to `__version__` at import time via `git rev-parse`, `uv build` fails with a version mismatch:

- **sdist**: built from the checkout (git available) → version = `X.Y.Z+<sha>`
- **wheel**: built from the extracted sdist (no `.git`) → version = `X.Y.Z`
- `uv` rejects: *"The source distribution declares version X.Y.Z+sha, but the wheel declares version X.Y.Z"*

Setting `NO_VCS_VERSION=1` disables the git suffix during CI wheel builds, where CI already manages versioning via the `PATCH = <run_number>` sed. The sha suffix is only meaningful for VCS installs (`pip install git+https://...`), not published wheels.

This env var is a no-op for repos that don't implement `NO_VCS_VERSION` in their `package_info.py`.

## Test plan

- [ ] CI passes on this PR
- [ ] Downstream repo using dynamic git versioning (NVIDIA-NeMo/Automodel#1729) builds successfully after bumping to the new template version