### PR TITLE
feat: add reusable _sync_skills workflow and CLAUDE.md

### DIFF
--- a/.github/workflows/_sync_skills.yml
+++ b/.github/workflows/_sync_skills.yml
@@ -1,0 +1,53 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Sync skills → agent dirs
+
+on:
+  workflow_call:
+    secrets:
+      PAT:
+        required: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT }}
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Symlink skills/ into agent dirs
+        run: |
+          for dir in .claude .agents; do
+            mkdir -p "$dir"
+            ln -sfn ../skills "$dir/skills"
+          done
+
+      - name: Symlink AGENTS.md → CLAUDE.md
+        run: '[ -f AGENTS.md ] && ln -sf AGENTS.md CLAUDE.md || true'
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude/skills .agents/skills CLAUDE.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+          BRANCH="${{ github.head_ref || github.ref_name }}"
+          git commit -m "chore(beep boop 🤖): symlink skills/ → .claude/skills, .agents/skills and AGENTS.md → CLAUDE.md"
+          git push origin HEAD:"$BRANCH"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md — FW-CI-templates
+
+## Commits
+
+Every commit message **must** start with one of:
+
+- `feat:` — new workflow, action, or feature
+- `fix:` — bug fix or correction to existing behavior
+- `refactor:` — restructuring with no behavior change
+
+## Pull Requests
+
+PR titles follow the same rule — they **must** start with `feat:`, `fix:`, or `refactor:`.


### PR DESCRIPTION
## Summary

- Extracts the `sync-skills` logic from NeMo-LM into a reusable `workflow_call` workflow
- Callers get the symlink + commit/push behavior by passing a single `PAT` secret

## Usage

```yaml
jobs:
  sync:
    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_sync_skills.yml@main
    secrets:
      PAT: ${{ secrets.PAT }}
```

## Test plan

- [ ] Merge this PR
- [ ] Update NeMo-LM `sync-skills.yml` to call this workflow and verify the push trigger fires correctly