### PR TITLE
feat: Use LLM for identifying follow-up issues

### DIFF
--- a/.github/actions/identify-follow-up-issues/action.yml
+++ b/.github/actions/identify-follow-up-issues/action.yml
@@ -25,6 +25,15 @@ inputs:
   org:
     description: GitHub organization name
     required: true
+  openai_base_url:
+    description: Base URL for the OpenAI-compatible API
+    required: true
+  openai_api_key:
+    description: API key for the LLM endpoint
+    required: true
+  llm_model:
+    description: Model name to use for classification
+    required: true
 
 runs:
   using: 'composite'
@@ -35,6 +44,9 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         PROJECT_ID: ${{ inputs.project_id }}
         ORG: ${{ inputs.org }}
+        OPENAI_BASE_URL: ${{ inputs.openai_base_url }}
+        OPENAI_API_KEY: ${{ inputs.openai_api_key }}
+        LLM_MODEL: ${{ inputs.llm_model }}
       run: |
         pip install requests
         python ${GITHUB_ACTION_PATH}/identify_follow_up_issues.py --project-id $PROJECT_ID --org $ORG --update-labels

--- a/.github/actions/identify-follow-up-issues/action.yml
+++ b/.github/actions/identify-follow-up-issues/action.yml
@@ -48,5 +48,5 @@ runs:
         OPENAI_API_KEY: ${{ inputs.openai_api_key }}
         LLM_MODEL: ${{ inputs.llm_model }}
       run: |
-        pip install requests
+        pip install requests openai
         python ${GITHUB_ACTION_PATH}/identify_follow_up_issues.py --project-id $PROJECT_ID --org $ORG --update-labels

--- a/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
+++ b/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
@@ -12,31 +12,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Updates the 'needs-follow-up' label on issues and PRs that need attention for on-call support.
+"""Classifies issues and PRs as waiting on author or maintainers using an LLM.
 
-Issues and PRs that need follow-up are community items that have not been responded to in 48 hours.
-The item requires a response if the last commenter is the original author.
+Uses the latest comment or review comment on each issue/PR to determine whether
+the item is waiting on the original author or waiting on maintainers. Items
+waiting on maintainers receive the 'needs-follow-up' label.
 
-For PRs, both issue-level comments and review (inline) comments are considered. If someone other
-than the author leaves a review comment, that counts as follow-up and the label is removed.
-
-If an author pushes new commits after a reviewer's feedback, those commits are treated as author
-activity. The needs-follow-up label will be re-applied after 48 hours if the reviewer hasn't
-responded to the new commits.
+Requires the following environment variables:
+- GITHUB_TOKEN: GitHub Personal Access Token
+- OPENAI_BASE_URL: Base URL for the OpenAI-compatible API
+- OPENAI_API_KEY: API key for the LLM endpoint
+- LLM_MODEL: Model name to use for classification
 """
 import argparse
 import csv
 import os
 from datetime import datetime, timedelta, timezone
 
+import openai
 import requests
-
 
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 GITHUB_REST_API_URL = "https://api.github.com"
 NEEDS_FOLLOWUP_LABEL = "needs-follow-up"
-LABEL_COLOR = "d93f0b"
-LABEL_DESCRIPTION = "Issue needs follow-up"
+NEEDS_FOLLOWUP_COLOR = "d93f0b"
+NEEDS_FOLLOWUP_DESCRIPTION = "Issue needs follow-up"
+
+WAITING_ON_CUSTOMER_LABEL = "waiting-on-customer"
+WAITING_ON_CUSTOMER_COLOR = "c2e0c6"
+WAITING_ON_CUSTOMER_DESCRIPTION = "Waiting on the original author to respond"
+
+CLASSIFICATION_SYSTEM_PROMPT = """\
+You are classifying GitHub issues and pull requests. Based on the conversation \
+context provided, determine whether the item is currently waiting on the \
+original author or waiting on the maintainers/reviewers to respond.
+
+Respond with exactly one of:
+- waiting-on-author
+- waiting-on-maintainers
+
+Rules:
+- If the latest comment is from the original author (or another community \
+member) asking a question, reporting a problem, or requesting help, it is \
+waiting-on-maintainers.
+- If the latest comment is from a maintainer/reviewer asking for changes, \
+requesting information, or asking the author to do something, it is \
+waiting-on-author.
+- If the latest comment is from a maintainer/reviewer providing an answer, \
+explanation, guidance, solution, or code review feedback, the ball is back \
+with the author — classify as waiting-on-author. The author is expected to \
+acknowledge, follow up, or close the issue.
+- If a maintainer's comment fully resolves the discussion with no open \
+questions remaining for the maintainers, it is waiting-on-author.
+- Only classify as waiting-on-maintainers if there is a clear unanswered \
+question or request directed at the maintainers.
+- If unsure, default to waiting-on-maintainers.
+
+Respond with ONLY "waiting-on-author" or "waiting-on-maintainers", nothing else."""
 
 
 def run_graphql_query(query: str, variables: dict, token: str) -> dict:
@@ -68,44 +100,31 @@ def run_graphql_query(query: str, variables: dict, token: str) -> dict:
     return result
 
 
-def ensure_label_exists(org: str, repo: str, token: str) -> bool:
-    """Ensure the 'needs-follow-up' label exists in the repository.
-
-    Creates it if it doesn't exist.
-
-    Args:
-        org: GitHub organization name
-        repo: Repository name
-        token: GitHub personal access token
-
-    Returns:
-        True if label exists or was created successfully, False otherwise
-    """
+def ensure_label_exists(org: str, repo: str, label_name: str, label_color: str, label_description: str, token: str) -> bool:
+    """Ensure a label exists in the repository. Creates it if missing."""
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    # Check if label exists
-    url = f"{GITHUB_REST_API_URL}/repos/{org}/{repo}/labels/{NEEDS_FOLLOWUP_LABEL}"
+    url = f"{GITHUB_REST_API_URL}/repos/{org}/{repo}/labels/{label_name}"
     response = requests.get(url, headers=headers)
 
     if response.status_code == 200:
-        return True  # Label already exists
+        return True
 
     if response.status_code == 404:
-        # Label doesn't exist, create it
         create_url = f"{GITHUB_REST_API_URL}/repos/{org}/{repo}/labels"
         label_data = {
-            "name": NEEDS_FOLLOWUP_LABEL,
-            "color": LABEL_COLOR,
-            "description": LABEL_DESCRIPTION,
+            "name": label_name,
+            "color": label_color,
+            "description": label_description,
         }
         create_response = requests.post(create_url, headers=headers, json=label_data)
 
         if create_response.status_code == 201:
-            print(f"  Created label '{NEEDS_FOLLOWUP_LABEL}' in {org}/{repo}")
+            print(f"  Created label '{label_name}' in {org}/{repo}")
             return True
         else:
             print(f"  Warning: Failed to create label in {org}/{repo}: {create_response.status_code}")
@@ -115,18 +134,8 @@ def ensure_label_exists(org: str, repo: str, token: str) -> bool:
     return False
 
 
-def add_label_to_issue(org: str, repo: str, issue_number: int, token: str) -> bool:
-    """Add the 'needs-follow-up' label to an issue.
-
-    Args:
-        org: GitHub organization name
-        repo: Repository name
-        issue_number: Issue number
-        token: GitHub personal access token
-
-    Returns:
-        True if label was added successfully, False otherwise
-    """
+def add_label_to_issue(org: str, repo: str, issue_number: int, label_name: str, token: str) -> bool:
+    """Add a label to an issue."""
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
@@ -134,7 +143,7 @@ def add_label_to_issue(org: str, repo: str, issue_number: int, token: str) -> bo
     }
 
     url = f"{GITHUB_REST_API_URL}/repos/{org}/{repo}/issues/{issue_number}/labels"
-    response = requests.post(url, headers=headers, json={"labels": [NEEDS_FOLLOWUP_LABEL]})
+    response = requests.post(url, headers=headers, json={"labels": [label_name]})
     if response.status_code == 200:
         return True
     else:
@@ -142,31 +151,20 @@ def add_label_to_issue(org: str, repo: str, issue_number: int, token: str) -> bo
         return False
 
 
-def remove_label_from_issue(org: str, repo: str, issue_number: int, token: str) -> bool:
-    """Remove the 'needs-follow-up' label from an issue.
-
-    Args:
-        org: GitHub organization name
-        repo: Repository name
-        issue_number: Issue number
-        token: GitHub personal access token
-
-    Returns:
-        True if label was removed successfully, False otherwise
-    """
+def remove_label_from_issue(org: str, repo: str, issue_number: int, label_name: str, token: str) -> bool:
+    """Remove a label from an issue."""
     headers = {
         "Authorization": f"Bearer {token}",
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    url = f"{GITHUB_REST_API_URL}/repos/{org}/{repo}/issues/{issue_number}/labels/{NEEDS_FOLLOWUP_LABEL}"
+    url = f"{GITHUB_REST_API_URL}/repos/{org}/{repo}/issues/{issue_number}/labels/{label_name}"
     response = requests.delete(url, headers=headers)
 
     if response.status_code in (200, 204):
         return True
     elif response.status_code == 404:
-        # Label was already not on the issue
         return True
     else:
         print(f"  Warning: Failed to remove label from {org}/{repo}#{issue_number}: {response.status_code}")
@@ -174,140 +172,145 @@ def remove_label_from_issue(org: str, repo: str, issue_number: int, token: str) 
 
 
 def get_repo_org(repo: str, default_org: str) -> str:
-    """Get the organization for a given repository.
-
-    Some repos have hardcoded orgs that differ from the project org.
-
-    Args:
-        repo: Repository name
-        default_org: Default organization to use
-
-    Returns:
-        The organization name for the repository
-    """
-    # Hardcoded org overrides for specific repos
+    """Get the organization for a given repository."""
     repo_org_overrides = {
         "Megatron-LM": "NVIDIA",
     }
     return repo_org_overrides.get(repo, default_org)
 
 
-def apply_labels_to_issues_needing_attention(issues: list[dict], org: str, token: str):
-    """Apply the 'needs-follow-up' label to all issues that need attention
+def classify_with_llm(client: openai.OpenAI, model: str, item: dict) -> str:
+    """Classify an issue/PR as waiting-on-author or waiting-on-maintainers using an LLM.
 
     Args:
-        issues: List of issue dictionaries
-        org: GitHub organization name
-        token: GitHub personal access token
+        client: OpenAI client instance
+        model: Model name to use
+        item: Item dictionary with issue/PR metadata including recent comments
+
+    Returns:
+        "waiting-on-author" or "waiting-on-maintainers"
     """
-    # Filter for issues that need attention AND don't already have the label
-    # Exclude Megatron-LM PRs targeting 'dev' branch and draft PRs
-    issues_to_label = [
-        i for i in issues
-        if i["needs_attention"]
-        and not i["has_followup_label"]
-        and not (
-            i["repo_name"] == "Megatron-LM"
-            and i["item_type"] == "PullRequest"
-            and i.get("target_branch") == "dev"
+    recent_comments = item.get("recent_comments", [])
+    if not recent_comments:
+        # No comments — item is waiting on maintainers by default
+        return "waiting-on-maintainers"
+
+    comments_text = ""
+    for comment in recent_comments:
+        comments_text += f"\n[{comment['author']}]: {comment['body']}\n"
+
+    user_prompt = f"""\
+Item type: {item["item_type"]}
+Title: {item["issue_title"]}
+Original author: {item["issue_author"]}
+
+Recent comments (oldest to newest):
+{comments_text}"""
+
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": CLASSIFICATION_SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            temperature=0,
+            max_tokens=50,
         )
-        and not (i["item_type"] == "PullRequest" and i.get("is_draft"))
-    ]
+        raw = response.choices[0].message.content.strip().lower()
 
-    if not issues_to_label:
-        print("No issues need the 'needs-follow-up' label (all already labeled or none need attention).")
-        return
+        # Extract classification from response, handling extra text or partial matches
+        if "waiting-on-maintainers" in raw:
+            return "waiting-on-maintainers"
+        if "waiting-on-author" in raw:
+            return "waiting-on-author"
 
-    print(f"\nApplying '{NEEDS_FOLLOWUP_LABEL}' label to {len(issues_to_label)} issues...")
+        print(f"  Warning: Unexpected LLM response '{classification}' for {item['repo_name']}#{item['issue_id']}, defaulting to waiting-on-maintainers")
+        return "waiting-on-maintainers"
 
-    # Track repos where we've already ensured the label exists
-    repos_with_label: set[str] = set()
-    labeled_count = 0
+    except Exception as e:
+        print(f"  Warning: LLM classification failed for {item['repo_name']}#{item['issue_id']}: {e}")
+        return "waiting-on-maintainers"
 
-    for issue in issues_to_label:
+
+def _is_excluded(item: dict) -> bool:
+    """Check if an item is excluded from labeling (Megatron-LM dev PRs, draft PRs)."""
+    return (
+        (
+            item["repo_name"] == "Megatron-LM"
+            and item["item_type"] == "PullRequest"
+            and item.get("target_branch") == "dev"
+        )
+        or (item["item_type"] == "PullRequest" and item.get("is_draft"))
+    )
+
+
+def update_labels(issues: list[dict], org: str, token: str):
+    """Update labels on all issues based on LLM classification.
+
+    - waiting-on-maintainers (needs_attention=True): add needs-follow-up, remove waiting-on-customer
+    - waiting-on-author (needs_attention=False): add waiting-on-customer, remove needs-follow-up
+    - Excluded items (Megatron-LM dev PRs, draft PRs): remove both labels
+    """
+    # Track repos where we've already ensured each label exists
+    repos_with_followup_label: set[str] = set()
+    repos_with_waiting_label: set[str] = set()
+
+    followup_added = 0
+    followup_removed = 0
+    waiting_added = 0
+    waiting_removed = 0
+
+    for issue in issues:
         repo = issue["repo_name"]
         issue_number = issue["issue_id"]
-
-        # Get the correct org for this repo (some repos have hardcoded orgs)
         repo_org = get_repo_org(repo, org)
+        excluded = _is_excluded(issue)
+        classification = issue.get("classification", "")
 
-        # Ensure label exists in this repo (only check once per repo)
-        if repo not in repos_with_label:
-            if ensure_label_exists(repo_org, repo, token):
-                repos_with_label.add(repo)
-            else:
-                continue  # Skip this issue if we couldn't create the label
+        # Handle needs-follow-up label
+        if issue["needs_attention"] and not issue["has_followup_label"] and not excluded:
+            if repo not in repos_with_followup_label:
+                if ensure_label_exists(repo_org, repo, NEEDS_FOLLOWUP_LABEL, NEEDS_FOLLOWUP_COLOR, NEEDS_FOLLOWUP_DESCRIPTION, token):
+                    repos_with_followup_label.add(repo)
+                else:
+                    continue
+            if add_label_to_issue(repo_org, repo, issue_number, NEEDS_FOLLOWUP_LABEL, token):
+                followup_added += 1
+        elif issue["has_followup_label"] and (not issue["needs_attention"] or excluded):
+            if remove_label_from_issue(repo_org, repo, issue_number, NEEDS_FOLLOWUP_LABEL, token):
+                followup_removed += 1
 
-        # Add label to the issue
-        if add_label_to_issue(repo_org, repo, issue_number, token):
-            labeled_count += 1
+        # Handle waiting-on-customer label
+        if classification == "waiting-on-author" and not issue["has_waiting_on_customer_label"] and not excluded:
+            if repo not in repos_with_waiting_label:
+                if ensure_label_exists(repo_org, repo, WAITING_ON_CUSTOMER_LABEL, WAITING_ON_CUSTOMER_COLOR, WAITING_ON_CUSTOMER_DESCRIPTION, token):
+                    repos_with_waiting_label.add(repo)
+                else:
+                    continue
+            if add_label_to_issue(repo_org, repo, issue_number, WAITING_ON_CUSTOMER_LABEL, token):
+                waiting_added += 1
+        elif issue["has_waiting_on_customer_label"] and classification != "waiting-on-author":
+            if remove_label_from_issue(repo_org, repo, issue_number, WAITING_ON_CUSTOMER_LABEL, token):
+                waiting_removed += 1
 
-    print(f"Successfully labeled {labeled_count} of {len(issues_to_label)} issues.")
-
-
-def remove_labels_from_resolved_issues(issues: list[dict], org: str, token: str):
-    """Remove the 'needs-follow-up' label from issues that no longer need follow-up.
-
-    An issue no longer needs follow-up if:
-    - The last commenter is not the issue author, OR
-    - The item is a Megatron-LM PR targeting the 'dev' branch, OR
-    - The item is a draft PR
-
-    Args:
-        issues: List of issue dictionaries
-        org: GitHub organization name
-        token: GitHub personal access token
-    """
-    # Filter for issues that have the label and either:
-    # - No longer need attention, OR
-    # - Are Megatron-LM PRs targeting 'dev' branch, OR
-    # - Are draft PRs
-    issues_to_unlabel = [
-        i for i in issues
-        if i["has_followup_label"]
-        and (
-            not i["needs_attention"]
-            or (
-                i["repo_name"] == "Megatron-LM"
-                and i["item_type"] == "PullRequest"
-                and i.get("target_branch") == "dev"
-            )
-            or (i["item_type"] == "PullRequest" and i.get("is_draft"))
-        )
-    ]
-
-    if not issues_to_unlabel:
-        print(f"No issues need the '{NEEDS_FOLLOWUP_LABEL}' label removed.")
-        return
-
-    print(f"\nRemoving '{NEEDS_FOLLOWUP_LABEL}' label from {len(issues_to_unlabel)} resolved issues...")
-
-    removed_count = 0
-
-    for issue in issues_to_unlabel:
-        repo = issue["repo_name"]
-        issue_number = issue["issue_id"]
-
-        # Get the correct org for this repo (some repos have hardcoded orgs)
-        repo_org = get_repo_org(repo, org)
-
-        # Remove label from the issue
-        if remove_label_from_issue(repo_org, repo, issue_number, token):
-            removed_count += 1
-
-    print(f"Successfully removed label from {removed_count} of {len(issues_to_unlabel)} issues.")
+    print(f"\n'{NEEDS_FOLLOWUP_LABEL}': added={followup_added}, removed={followup_removed}")
+    print(f"'{WAITING_ON_CUSTOMER_LABEL}': added={waiting_added}, removed={waiting_removed}")
 
 
-def fetch_project_items(org: str, project_number: int, token: str) -> list[dict]:
-    """Fetch all open issues and pull requests from a GitHub Project.
+def fetch_project_items(org: str, project_number: int, token: str, llm_client: openai.OpenAI, llm_model: str, limit: int = 0) -> list[dict]:
+    """Fetch all open issues and pull requests from a GitHub Project and classify them with an LLM.
 
     Args:
         org: GitHub organization name
         project_number: The project number (not the node ID)
         token: GitHub personal access token
+        llm_client: OpenAI client for LLM classification
+        llm_model: Model name to use for classification
+        limit: Maximum number of items to process (0 for unlimited)
 
     Returns:
-        List of item dictionaries with id, title, repo, created_at, last commenter, and last comment date
+        List of item dictionaries with classification results
     """
     query = """
     query($org: String!, $projectNumber: Int!, $cursor: String) {
@@ -341,6 +344,7 @@ def fetch_project_items(org: str, project_number: int, token: str) -> list[dict]
                         login
                       }
                       createdAt
+                      body
                     }
                   }
                   labels(first: 100) {
@@ -371,6 +375,7 @@ def fetch_project_items(org: str, project_number: int, token: str) -> list[dict]
                         login
                       }
                       createdAt
+                      body
                     }
                   }
                   reviewThreads(first: 50) {
@@ -382,34 +387,25 @@ def fetch_project_items(org: str, project_number: int, token: str) -> list[dict]
                             login
                           }
                           createdAt
+                          body
                         }
                       }
+                    }
+                  }
+                  reviews(last: 20) {
+                    nodes {
+                      author {
+                        __typename
+                        login
+                      }
+                      body
+                      state
+                      submittedAt
                     }
                   }
                   labels(first: 100) {
                     nodes {
                       name
-                    }
-                  }
-                  reviews(last: 1, states: APPROVED) {
-                    nodes {
-                      author {
-                        login
-                      }
-                      submittedAt
-                    }
-                  }
-                  changesRequestedReviews: reviews(last: 1, states: CHANGES_REQUESTED) {
-                    nodes {
-                      submittedAt
-                    }
-                  }
-                  commits(last: 1) {
-                    nodes {
-                      commit {
-                        pushedDate
-                        committedDate
-                      }
                     }
                   }
                 }
@@ -457,13 +453,14 @@ def fetch_project_items(org: str, project_number: int, token: str) -> list[dict]
             if item_type not in ("Issue", "PullRequest"):
                 continue
 
-            # Check if item already has the needs-follow-up label
+            # Check if item already has managed labels
             labels = content.get("labels", {}).get("nodes", [])
             label_names = [label.get("name", "") for label in labels]
             has_followup_label = NEEDS_FOLLOWUP_LABEL in label_names
+            has_waiting_on_customer_label = WAITING_ON_CUSTOMER_LABEL in label_names
 
             # Only include open issues/PRs
-            if content.get("state") != "OPEN" and not has_followup_label:
+            if content.get("state") != "OPEN" and not has_followup_label and not has_waiting_on_customer_label:
                 continue
 
             # Get author info
@@ -473,17 +470,12 @@ def fetch_project_items(org: str, project_number: int, token: str) -> list[dict]
             author_is_bot = author_type == "Bot"
             created_at = content.get("createdAt", "")
 
-            # Skip items authored by bots (e.g., Dependabot PRs)
+            # Skip items authored by bots
             if author_is_bot:
                 continue
 
-            # Find the last non-bot commenter from both issue comments and (for PRs) review comments
+            # Collect all non-bot activity with comment bodies
             comments = content.get("comments", {}).get("nodes", [])
-            last_commenter = author
-            last_commenter_is_bot = author_is_bot
-            last_comment_date = created_at
-
-            # Build list of (commenter_login, commenter_is_bot, date) from issue comments
             activity = []
             for comment in comments:
                 commenter_obj = comment.get("author", {}) or {}
@@ -492,9 +484,10 @@ def fetch_project_items(org: str, project_number: int, token: str) -> list[dict]
                     commenter_obj.get("login", ""),
                     commenter_type == "Bot",
                     comment.get("createdAt", ""),
+                    comment.get("body", ""),
                 ))
 
-            # For PRs, also include review thread (inline) comments; they are separate from issue comments
+            # For PRs, also include review thread (inline) comments and review bodies
             if item_type == "PullRequest":
                 for thread in content.get("reviewThreads", {}).get("nodes", []):
                     for comment in thread.get("comments", {}).get("nodes", []):
@@ -504,90 +497,96 @@ def fetch_project_items(org: str, project_number: int, token: str) -> list[dict]
                             commenter_obj.get("login", ""),
                             commenter_type == "Bot",
                             comment.get("createdAt", ""),
+                            comment.get("body", ""),
                         ))
 
-                # Include the last commit as author activity so that new commits pushed after
-                # reviewer feedback are treated as the author's response. This ensures the
-                # needs-follow-up label is re-applied after 48h if the reviewer hasn't responded.
-                commits = content.get("commits", {}).get("nodes", [])
-                if commits:
-                    commit = commits[0].get("commit", {})
-                    commit_date = commit.get("pushedDate") or commit.get("committedDate", "")
-                    if commit_date:
-                        activity.append((author, False, commit_date))
+                # Include top-level review bodies (Approve, Request changes, Comment)
+                for review in content.get("reviews", {}).get("nodes", []):
+                    review_body = review.get("body", "")
+                    if not review_body:
+                        continue
+                    reviewer_obj = review.get("author", {}) or {}
+                    reviewer_type = reviewer_obj.get("__typename", "")
+                    state = review.get("state", "")
+                    prefix = f"[Review: {state}] " if state else ""
+                    activity.append((
+                        reviewer_obj.get("login", ""),
+                        reviewer_type == "Bot",
+                        review.get("submittedAt", ""),
+                        prefix + review_body,
+                    ))
 
-            # Use the chronologically latest non-bot activity
+            # Find recent non-bot comments (last 5, chronological order)
+            last_commenter = author
+            last_comment_date = created_at
+
             activity.sort(key=lambda x: x[2], reverse=True)
-            for commenter_login, is_bot, date in activity:
-                if not is_bot:
-                    last_commenter = commenter_login
-                    last_commenter_is_bot = False
-                    last_comment_date = date
-                    break
+            non_bot_activity = [(login, date, body) for login, is_bot, date, body in activity if not is_bot]
 
-            # Get PR approval info, changes requested info, target branch, and draft status (only for PRs)
-            is_approved = False
-            last_approval_date = ""
-            last_approver = ""
-            has_changes_requested = False
+            if non_bot_activity:
+                last_commenter = non_bot_activity[0][0]
+                last_comment_date = non_bot_activity[0][1]
+
+            # Take last 5 non-bot comments in chronological order (oldest first)
+            recent_comments = [
+                {"author": login, "body": body}
+                for login, date, body in reversed(non_bot_activity[:5])
+            ]
+
+            # Get target branch and draft status for PRs
             target_branch = ""
             is_draft = False
             if item_type == "PullRequest":
                 target_branch = content.get("baseRefName", "")
                 is_draft = content.get("isDraft", False)
-                reviews = content.get("reviews", {}).get("nodes", [])
-                if len(reviews) > 0:
-                    is_approved = True
-                    last_review = reviews[0]
-                    last_approval_date = datetime.fromisoformat(last_review.get("submittedAt", "").replace("Z", "+00:00"))
-                    last_approver = last_review.get("author", {}).get("login", "")
 
-                # Check for changes requested reviews - if any exist, PR doesn't need attention
-                changes_requested_reviews = content.get("changesRequestedReviews", {}).get("nodes", [])
-                if len(changes_requested_reviews) > 0:
-                    has_changes_requested = True
-
-            # Determine if item needs attention:
-            # - If the last commenter is the author and the last comment is more than 48 hours old
-            # - OR if the PR is approved, last approval is more than 48 hours old, and no changes requested
-            needs_attention = False
-            comment_dt = datetime.fromisoformat(last_comment_date.replace("Z", "+00:00"))
-            if (
-                (
-                    last_commenter == author and
-                    comment_dt < datetime.now(timezone.utc) - timedelta(hours=48)
-                ) or
-                (
-                    is_approved and
-                    not has_changes_requested and
-                    last_approval_date < datetime.now(timezone.utc) - timedelta(hours=48)
-                )
-            ):
-                needs_attention = True
-
-            if content.get("state") != "OPEN":
-                needs_attention = False
+            repo_name = content.get("repository", {}).get("name", "")
+            issue_number = content.get("number")
+            repo_org = get_repo_org(repo_name, org)
+            url = f"https://github.com/{repo_org}/{repo_name}/issues/{issue_number}"
+            if item_type == "PullRequest":
+                url = f"https://github.com/{repo_org}/{repo_name}/pull/{issue_number}"
 
             item_dict = {
                 "item_type": item_type,
-                "issue_id": content.get("number"),
+                "issue_id": issue_number,
                 "issue_title": content.get("title"),
-                "repo_name": content.get("repository", {}).get("name", ""),
+                "repo_name": repo_name,
+                "url": url,
                 "issue_author": author,
                 "author_is_bot": author_is_bot,
                 "issue_created_date": created_at,
                 "last_commenter": last_commenter,
-                "last_commenter_is_bot": last_commenter_is_bot,
                 "last_comment_date": last_comment_date,
-                "needs_attention": needs_attention,
+                "recent_comments": recent_comments,
                 "has_followup_label": has_followup_label,
-                "is_approved": is_approved,
-                "last_approval_date": last_approval_date,
-                "last_approver": last_approver,
+                "has_waiting_on_customer_label": has_waiting_on_customer_label,
                 "target_branch": target_branch,
                 "is_draft": is_draft,
             }
+
+            # Classify with LLM — skip closed items
+            if content.get("state") != "OPEN":
+                item_dict["needs_attention"] = False
+            else:
+                classification = classify_with_llm(llm_client, llm_model, item_dict)
+                item_dict["classification"] = classification
+
+                # Only flag as needing attention if classified as waiting-on-maintainers
+                # AND the last comment is more than 48 hours old
+                comment_dt = datetime.fromisoformat(last_comment_date.replace("Z", "+00:00"))
+                is_stale = comment_dt < datetime.now(timezone.utc) - timedelta(hours=48)
+                item_dict["needs_attention"] = classification == "waiting-on-maintainers" and is_stale
+                print(f"  {item_dict['url']}: {classification} (stale={is_stale})")
+
             items_list.append(item_dict)
+
+            if limit and len(items_list) >= limit:
+                print(f"Reached limit of {limit} items.")
+                break
+
+        if limit and len(items_list) >= limit:
+            break
 
         page_info = project.get("items", {}).get("pageInfo", {})
 
@@ -602,16 +601,81 @@ def fetch_project_items(org: str, project_number: int, token: str) -> list[dict]
     pr_count = sum(1 for i in items_list if i["item_type"] == "PullRequest")
     print(f"Found {len(items_list)} open items ({issue_count} issues, {pr_count} PRs)")
     needs_attention_count = sum(1 for i in items_list if i["needs_attention"])
-    print(f"Items needing attention: {needs_attention_count}")
+    print(f"Items needing attention (waiting-on-maintainers): {needs_attention_count}")
     has_label_count = sum(1 for i in items_list if i["has_followup_label"])
     print(f"Items with '{NEEDS_FOLLOWUP_LABEL}' label: {has_label_count}")
     return items_list
 
 
+def write_debug_csv(items: list[dict], org: str, output_path: str):
+    """Write planned label changes to a CSV file for debugging.
+
+    Args:
+        items: List of item dictionaries with classification results
+        org: GitHub organization name
+        output_path: Path to write the CSV file
+    """
+    fieldnames = [
+        "url",
+        "repo",
+        "number",
+        "type",
+        "title",
+        "author",
+        "last_commenter",
+        "classification",
+        "has_followup_label",
+        "followup_action",
+        "has_waiting_on_customer_label",
+        "waiting_on_customer_action",
+    ]
+
+    with open(output_path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+
+        for item in items:
+            excluded = _is_excluded(item)
+            classification = item.get("classification", "")
+
+            # Determine needs-follow-up action
+            if item.get("needs_attention") and not item["has_followup_label"] and not excluded:
+                followup_action = "add-label"
+            elif item["has_followup_label"] and (not item.get("needs_attention") or excluded):
+                followup_action = "remove-label"
+            else:
+                followup_action = "no-change"
+
+            # Determine waiting-on-customer action
+            if classification == "waiting-on-author" and not item["has_waiting_on_customer_label"] and not excluded:
+                waiting_action = "add-label"
+            elif item["has_waiting_on_customer_label"] and classification != "waiting-on-author":
+                waiting_action = "remove-label"
+            else:
+                waiting_action = "no-change"
+
+            writer.writerow({
+                "url": item["url"],
+                "repo": f"{get_repo_org(item['repo_name'], org)}/{item['repo_name']}",
+                "number": item["issue_id"],
+                "type": item["item_type"],
+                "title": item["issue_title"],
+                "author": item["issue_author"],
+                "last_commenter": item["last_commenter"],
+                "classification": classification,
+                "has_followup_label": item["has_followup_label"],
+                "followup_action": followup_action,
+                "has_waiting_on_customer_label": item["has_waiting_on_customer_label"],
+                "waiting_on_customer_action": waiting_action,
+            })
+
+    print(f"Debug CSV written to {output_path}")
+
+
 def main():
-    """Add or remove the 'needs-follow-up' label to issues and PRs that need attention"""
+    """Classify issues/PRs and manage the 'needs-follow-up' label using LLM classification."""
     parser = argparse.ArgumentParser(
-        description="Add or remove the 'needs-follow-up' label to issues and PRs that need attention"
+        description="Classify issues/PRs as waiting-on-author or waiting-on-maintainers using an LLM"
     )
     parser.add_argument(
         "--project-id",
@@ -628,17 +692,33 @@ def main():
     parser.add_argument(
         "--update-labels",
         action="store_true",
-        help="Add or remove the 'needs-follow-up' label to issues and PRs that need attention",
+        help="Add or remove the 'needs-follow-up' label based on LLM classification",
+    )
+    parser.add_argument(
+        "--debug",
+        type=str,
+        metavar="CSV_PATH",
+        help="Write planned label changes to a CSV file at the given path",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Maximum number of items to process (default: all)",
     )
 
     args = parser.parse_args()
     token = os.environ["GITHUB_TOKEN"]
-    items = fetch_project_items(args.org, args.project_id, token)
+    llm_model = os.environ["LLM_MODEL"]
+
+    llm_client = openai.OpenAI()
+
+    items = fetch_project_items(args.org, args.project_id, token, llm_client, llm_model, limit=args.limit)
+    if args.debug:
+        write_debug_csv(items, args.org, args.debug)
     if args.update_labels:
-        apply_labels_to_issues_needing_attention(items, args.org, token)
-        remove_labels_from_resolved_issues(items, args.org, token)
+        update_labels(items, args.org, token)
 
 
 if __name__ == "__main__":
     main()
-

--- a/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
+++ b/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
@@ -281,8 +281,9 @@ def update_labels(issues: list[dict], org: str, token: str):
             if remove_label_from_issue(repo_org, repo, issue_number, NEEDS_FOLLOWUP_LABEL, token):
                 followup_removed += 1
 
-        # Handle waiting-on-customer label
-        if classification == "waiting-on-author" and not issue["has_waiting_on_customer_label"] and not excluded:
+        # Handle waiting-on-customer label (mutually exclusive with needs-follow-up)
+        wants_waiting_label = classification == "waiting-on-author" and not issue["needs_attention"] and not excluded
+        if wants_waiting_label and not issue["has_waiting_on_customer_label"]:
             if repo not in repos_with_waiting_label:
                 if ensure_label_exists(repo_org, repo, WAITING_ON_CUSTOMER_LABEL, WAITING_ON_CUSTOMER_COLOR, WAITING_ON_CUSTOMER_DESCRIPTION, token):
                     repos_with_waiting_label.add(repo)
@@ -290,7 +291,7 @@ def update_labels(issues: list[dict], org: str, token: str):
                     continue
             if add_label_to_issue(repo_org, repo, issue_number, WAITING_ON_CUSTOMER_LABEL, token):
                 waiting_added += 1
-        elif issue["has_waiting_on_customer_label"] and classification != "waiting-on-author":
+        elif issue["has_waiting_on_customer_label"] and not wants_waiting_label:
             if remove_label_from_issue(repo_org, repo, issue_number, WAITING_ON_CUSTOMER_LABEL, token):
                 waiting_removed += 1
 
@@ -533,12 +534,20 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
                 for login, date, body in reversed(non_bot_activity[:5])
             ]
 
-            # Get target branch and draft status for PRs
+            # Get target branch, draft status, and approval info for PRs
             target_branch = ""
             is_draft = False
+            last_approval_date = ""
             if item_type == "PullRequest":
                 target_branch = content.get("baseRefName", "")
                 is_draft = content.get("isDraft", False)
+
+                # Find the latest approval date
+                for review in content.get("reviews", {}).get("nodes", []):
+                    if review.get("state") == "APPROVED":
+                        submitted = review.get("submittedAt", "")
+                        if submitted > last_approval_date:
+                            last_approval_date = submitted
 
             repo_name = content.get("repository", {}).get("name", "")
             issue_number = content.get("number")
@@ -563,6 +572,7 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
                 "has_waiting_on_customer_label": has_waiting_on_customer_label,
                 "target_branch": target_branch,
                 "is_draft": is_draft,
+                "last_approval_date": last_approval_date,
             }
 
             # Classify with LLM — skip closed items
@@ -577,7 +587,15 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
                 comment_dt = datetime.fromisoformat(last_comment_date.replace("Z", "+00:00"))
                 is_stale = comment_dt < datetime.now(timezone.utc) - timedelta(hours=48)
                 item_dict["needs_attention"] = classification == "waiting-on-maintainers" and is_stale
-                print(f"  {item_dict['url']}: {classification} (stale={is_stale})")
+
+                # Approved PRs not merged after 48 hours always need follow-up
+                if item_type == "PullRequest" and last_approval_date:
+                    approval_dt = datetime.fromisoformat(last_approval_date.replace("Z", "+00:00"))
+                    approval_stale = approval_dt < datetime.now(timezone.utc) - timedelta(hours=48)
+                    if approval_stale:
+                        item_dict["needs_attention"] = True
+
+                print(f"  {item_dict['url']}: {classification} (stale={is_stale}, approved_unmerged={'48h+' if item_type == 'PullRequest' and last_approval_date and item_dict['needs_attention'] else 'n/a'})")
 
             items_list.append(item_dict)
 

--- a/.github/workflows/identify-follow-up-issues.yml
+++ b/.github/workflows/identify-follow-up-issues.yml
@@ -15,7 +15,7 @@
 name: Identify Follow Up Issues
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 */4 * * *'
   workflow_dispatch:
 
 jobs:
@@ -32,3 +32,6 @@ jobs:
           github_token: ${{ secrets.PAT }}
           project_id: ${{ vars.COMMUNITY_PROJECT_ID }}
           org: ${{ vars.COMMUNITY_PROJECT_ORG }}
+          openai_base_url: ${{ secrets.ISSUES_OPENAI_BASE_URL }}
+          openai_api_key: ${{ secrets.ISSUES_OPENAI_API_KEY }}
+          llm_model: ${{ vars.ISSUES_LLM_MODEL }}


### PR DESCRIPTION
feat: Use LLM for identifying follow-up issues

Previously, this script had some rules based on the last commenter to identify whether we needed to apply a needs-follow-up label for our on-call team. However, it was imperfect because the last commenter might just be acknowledging the problem rather than helping to resolve.

This also applies a waiting-for-customer label if the LLM believes that should be the case. We only run this every 4 hours instead of every hour.  Calling the LLM every hour for a few hundred issues might be a bit much.

Example run
https://github.com/NVIDIA-NeMo/FW-CI-templates/actions/runs/24609552357/job/71961441487
