### PR TITLE
fix(pre-commit): preserve matched filenames in `no-underscore-md` hook

### DIFF
--- a/github_repo_template/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/github_repo_template/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
       - id: no-underscore-md
         name: "Disallow '_' in Markdown filenames"
         language: system
+        # With `bash -c`, the first extra arg becomes `$0`, so `--` keeps matched filenames in `"$@"`.
         entry: |
           bash -c '
             # Report the offending files
@@ -45,7 +46,7 @@ repos:
               echo "  - $file (use hyphens instead)" >&2
             done
             exit 1
-          '
+          ' --
         files: '.*\/[^\/]*_[^\/]*\.md$'
         exclude: '^\.github/'
         types: [file]


### PR DESCRIPTION
Without `--`, the first matched filename is treated as `$0` by `bash -c`, which means the hook can fail without reporting every offending Markdown file.

- pass `--` to `bash -c` in the `no-underscore-md` local pre-commit hook
- add an inline comment explaining why the separator is required

```bash
bash -c 'echo "Hi! $@"' "foo" "bar"
# Hi! bar

bash -c 'echo "Hi! $@"' -- "foo" "bar"
# Hi! foo bar
```

I found this issue in https://github.com/NVIDIA-NeMo/Automodel/pull/1065/changes/a409ff1f86a629b824ee7714e9cc3610ac28bde3#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9 , and verified the fix in the `NVIDIA-NeMo/Automodel`.

Because I noticed that several repositories under `NVIDIA-NeMo` use this hook, I came across this repository as well. I'd be happy to submit the same fix to other affected repositories too.