### PR TITLE
feat: create next semver milestone on freeze

### DIFF
--- a/.github/workflows/_code_freeze.yml
+++ b/.github/workflows/_code_freeze.yml
@@ -192,9 +192,40 @@ jobs:
           signoff: true
           assignees: okoenig
 
+  create-milestone:
+    runs-on: ubuntu-latest
+    needs: [create-release-branch]
+    steps:
+      - name: Create next milestone
+        if: ${{ inputs.dry-run != true }}
+        env:
+          GH_TOKEN: ${{ inputs.use-pat && secrets.PAT || github.token }}
+        run: |
+          LATEST=$(gh api --paginate \
+            "repos/${{ github.repository }}/milestones?state=all&per_page=100" \
+            --jq '.[].title' \
+            | { grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || true; } \
+            | sort -V \
+            | tail -1)
+
+          if [[ -z "$LATEST" ]]; then
+            echo "No semver milestone found; skipping creation."
+            exit 0
+          fi
+
+          MAJOR=$(echo "$LATEST" | cut -d. -f1)
+          MINOR=$(echo "$LATEST" | cut -d. -f2)
+          NEXT_VERSION="${MAJOR}.$(( MINOR + 1 )).0"
+
+          echo "Latest milestone: $LATEST → creating $NEXT_VERSION"
+
+          gh api "repos/${{ github.repository }}/milestones" \
+            --method POST \
+            --field title="$NEXT_VERSION"
+
   notify:
     runs-on: ubuntu-latest
-    needs: [create-release-branch, bump-next-version]
+    needs: [create-release-branch, bump-next-version, create-milestone]
     environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
     env:
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Summary

- Adds a `create-milestone` job to `_code_freeze.yml` that runs after `create-release-branch`
- Queries all existing GitHub milestones (open + closed), filters for semver titles (`X.Y.Z`), picks the latest via `sort -V`, increments the minor component, and creates the new milestone via the GitHub API
- Skipped on dry-run (consistent with other write operations in the workflow); gracefully no-ops if no semver milestone exists yet
- `notify` now waits on `create-milestone` so the Slack message fires only after all three parallel tracks complete

## Example

If the latest milestone is `2.3.0`, the job creates `2.4.0`.

## Test plan

- [ ] Trigger a dry-run code freeze and verify `create-milestone` step is skipped
- [ ] Trigger a real code freeze and verify a new `X.(Y+1).0` milestone appears on the repo

</details>
