### PR TITLE
fix: bump _build_test_publish_wheel.yml to v0.88.1 in _release_library.yml

### DIFF
--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -222,7 +222,7 @@ jobs:
   build-test-publish-wheel-dry-run:
     name: Build test publish wheel (dry run)
     needs: check-admin-permission
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.87.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.88.1
     if: |
       (
         success() || !failure()
@@ -499,7 +499,7 @@ jobs:
           git push -d origin ${{ env.TMP_BRANCH }}
 
   build-test-publish-wheel:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.87.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.88.1
     needs: bump-next-version
     if: |
       (


### PR DESCRIPTION
  - Bumps both internal `_build_test_publish_wheel.yml` references (dry-run + publish paths) from `@v0.87.0` to `@v0.88.1`, which sets`NO_VCS_VERSION=1` in the wheel build env (#443).
  - Without this, consumers whose `package_info.py` mutates `__version__` from a runtime `git rev-parse` (e.g. NVIDIA-NeMo/Automodel) hit a PEP 440 sdist↔wheel version mismatch during release: the sdist phase runs in a git checkout (gets`+<sha>`) while the wheel phase runs from an extracted sdist with no `.git` (stays bare). Setting `NO_VCS_VERSION=1` short-circuits the append in both phases so the two artifacts agree.