### PR TITLE
feat: Major refactoring of the release-workflows

### DIFF
--- a/.github/workflows/_build_docs.yml
+++ b/.github/workflows/_build_docs.yml
@@ -50,6 +50,11 @@ on:
         required: false
         type: string
         default: "."
+      skip-linkcheck:
+        description: Skip the Sphinx linkcheck + broken-link validation. Use for repos that haven't curated a `broken_links_false_positives.json` yet.
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   main:
@@ -110,6 +115,7 @@ jobs:
           retention-days: 7
 
       - name: Sphinx linkcheck
+        if: inputs.skip-linkcheck == false
         working-directory: ${{ inputs.root-dir }}
         run: |
           source .venv/bin/activate
@@ -126,6 +132,7 @@ jobs:
           done
 
       - name: Upload linkcheck output
+        if: inputs.skip-linkcheck == false
         uses: actions/upload-artifact@v6
         with:
           name: linkcheck-artifact
@@ -133,6 +140,7 @@ jobs:
           retention-days: 7
 
       - name: Check for unknown broken links
+        if: inputs.skip-linkcheck == false
         working-directory: ${{ inputs.root-dir }}
         run: |
           FALSE_POSITIVES_JSON=${{ inputs.docs-directory }}/broken_links_false_positives.json

--- a/.github/workflows/_build_docs.yml
+++ b/.github/workflows/_build_docs.yml
@@ -45,6 +45,11 @@ on:
         required: false
         type: string
         default: ${{ github.sha }}
+      root-dir:
+        description: Sub-directory containing pyproject.toml (for monorepo consumers).
+        required: false
+        type: string
+        default: "."
 
 jobs:
   main:
@@ -63,6 +68,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
+        working-directory: ${{ inputs.root-dir }}
         env:
           NO_EXTRAS: ${{ inputs.no-extras }}
         run: |
@@ -83,6 +89,7 @@ jobs:
           fi
 
       - name: Sphinx build
+        working-directory: ${{ inputs.root-dir }}
         run: |
           source .venv/bin/activate
           cd ${{ inputs.docs-directory }}
@@ -99,10 +106,11 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: docs-html
-          path: ${{ inputs.docs-directory }}/_build/html
+          path: ${{ inputs.root-dir }}/${{ inputs.docs-directory }}/_build/html
           retention-days: 7
 
       - name: Sphinx linkcheck
+        working-directory: ${{ inputs.root-dir }}
         run: |
           source .venv/bin/activate
           cd ${{ inputs.docs-directory }}
@@ -121,10 +129,11 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: linkcheck-artifact
-          path: ${{ inputs.docs-directory }}/_build/linkcheck
+          path: ${{ inputs.root-dir }}/${{ inputs.docs-directory }}/_build/linkcheck
           retention-days: 7
 
       - name: Check for unknown broken links
+        working-directory: ${{ inputs.root-dir }}
         run: |
           FALSE_POSITIVES_JSON=${{ inputs.docs-directory }}/broken_links_false_positives.json
           NEEDS_REVIEW_JSON=${{ inputs.docs-directory }}/broken_links_needing_review.json

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -362,9 +362,8 @@ jobs:
         run: |
           check-wheel-contents --ignore W002,W004 dist/*.whl
 
-      - name: check-manifest (advisory)
+      - name: check-manifest
         if: inputs.packaging == 'setuptools'
-        continue-on-error: true
         run: |
           cd ${{ github.run_id }}
           cd $ROOTDIR
@@ -372,7 +371,7 @@ jobs:
             echo "::notice::No MANIFEST.in found; skipping check-manifest."
             exit 0
           fi
-          check-manifest -v || echo "::warning::check-manifest reported issues — see log."
+          check-manifest -v
 
   publish-wheel:
     needs: [test-wheel, validate-wheel]

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -54,6 +54,11 @@ on:
         description: Skip the test wheel step
         type: boolean
         default: false
+      wheel-content-ignore:
+        required: false
+        description: Comma-separated check-wheel-contents codes to ignore (e.g. "W002,W004,W009"). W002+W004 are common no-ops; add W009 for repos that ship multiple top-level packages in one wheel.
+        type: string
+        default: "W002,W004"
       custom-container:
         required: false
         description: Custom container to use for the build
@@ -360,7 +365,7 @@ jobs:
 
       - name: check-wheel-contents
         run: |
-          check-wheel-contents --ignore W002,W004 dist/*.whl
+          check-wheel-contents --ignore ${{ inputs.wheel-content-ignore }} dist/*.whl
 
       - name: check-manifest
         if: inputs.packaging == 'setuptools'

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -106,8 +106,6 @@ on:
         required: false
       SLACK_WEBHOOK_ADMIN:
         required: false
-      SLACK_WEBHOOK:
-        required: false
       GH_TOKEN:
         required: false
     outputs:

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -31,7 +31,7 @@ on:
         default: ${{ github.sha }}
       packaging:
         required: false
-        description: "Packaging tool (supported: setuptools, hatch, uv)"
+        description: "Packaging tool (supported: setuptools, uv)"
         type: string
         default: setuptools
       no-publish:

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -381,13 +381,9 @@ jobs:
   publish-wheel:
     needs: [test-wheel, validate-wheel]
     runs-on: ubuntu-latest
-    if: |
-      inputs.no-publish == false &&
-      (
-        inputs.skip-test-wheel == false || !cancelled()
-      )
+    if: inputs.skip-test-wheel == false || !cancelled()
     environment:
-      name: main
+      name: ${{ inputs.no-publish && 'public' || 'main' }}
     steps:
       - name: Download wheel
         uses: actions/download-artifact@v7
@@ -399,9 +395,18 @@ jobs:
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          DRY_RUN: ${{ inputs.no-publish }}
         run: |
           python3 -m pip install --upgrade twine==6.0.1
-          python3 -m twine upload --verbose --skip-existing -u $TWINE_USERNAME -p $TWINE_PASSWORD --repository pypi dist/*
+          ls -la dist/
+
+          if [[ "$DRY_RUN" == "false" ]]; then
+            [[ -z "$TWINE_USERNAME" ]] && { echo "::error::TWINE_USERNAME unset"; exit 1; }
+            [[ -z "$TWINE_PASSWORD" ]] && { echo "::error::TWINE_PASSWORD unset"; exit 1; }
+            python3 -m twine upload --verbose --skip-existing -u "$TWINE_USERNAME" -p "$TWINE_PASSWORD" --repository pypi dist/*
+          else
+            echo "[dry-run] would execute: python3 -m twine upload --verbose --skip-existing -u <user> -p <pass> --repository pypi dist/*"
+          fi
 
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -362,8 +362,9 @@ jobs:
         run: |
           check-wheel-contents --ignore W002,W004 dist/*.whl
 
-      - name: check-manifest
+      - name: check-manifest (advisory)
         if: inputs.packaging == 'setuptools'
+        continue-on-error: true
         run: |
           cd ${{ github.run_id }}
           cd $ROOTDIR
@@ -371,7 +372,7 @@ jobs:
             echo "::notice::No MANIFEST.in found; skipping check-manifest."
             exit 0
           fi
-          check-manifest -v
+          check-manifest -v || echo "::warning::check-manifest reported issues — see log."
 
   publish-wheel:
     needs: [test-wheel, validate-wheel]

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -54,6 +54,11 @@ on:
         description: Skip the test wheel step
         type: boolean
         default: false
+      skip-check-manifest:
+        required: false
+        description: Skip check-manifest validation. Use for repos that intentionally exclude dev tooling (`.claude/`, `docs/`, `docker/`, …) from the sdist without maintaining a `[tool.check-manifest] ignore` block.
+        type: boolean
+        default: false
       wheel-content-ignore:
         required: false
         description: Comma-separated check-wheel-contents codes to ignore (e.g. "W002,W004,W009"). W002+W004 are common no-ops; add W009 for repos that ship multiple top-level packages in one wheel.
@@ -368,7 +373,7 @@ jobs:
           check-wheel-contents --ignore ${{ inputs.wheel-content-ignore }} dist/*.whl
 
       - name: check-manifest
-        if: inputs.packaging == 'setuptools'
+        if: inputs.packaging == 'setuptools' && inputs.skip-check-manifest == false
         run: |
           cd ${{ github.run_id }}
           cd $ROOTDIR

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -39,6 +39,11 @@ on:
         description: Do not publish the wheel
         type: boolean
         default: false
+      suppress-failure-notify:
+        required: false
+        description: Suppress the failure Slack notification (used for PR rehearsals where failures should not page).
+        type: boolean
+        default: false
       has-src-dir:
         required: false
         description: Whether the package has a src directory
@@ -355,7 +360,7 @@ jobs:
 
       - name: check-wheel-contents
         run: |
-          check-wheel-contents dist/*.whl
+          check-wheel-contents --ignore W002,W004 dist/*.whl
 
       - name: check-manifest
         if: inputs.packaging == 'setuptools'
@@ -391,7 +396,7 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    if: failure()
+    if: failure() && inputs.suppress-failure-notify == false
     environment: public
     needs: [publish-wheel]
     env:

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -16,11 +16,6 @@ name: Build, test, and publish a PyPi wheel
 on:
   workflow_call:
     inputs:
-      dry-run:
-        required: false
-        description: Upload to PyPy Test instance
-        type: boolean
-        default: true
       python-package:
         type: string
         description: Name of Python package
@@ -91,9 +86,9 @@ on:
         default: ""
     secrets:
       TWINE_USERNAME:
-        required: true
+        required: false
       TWINE_PASSWORD:
-        required: true
+        required: false
       SLACK_WEBHOOK_ADMIN:
         required: false
       SLACK_WEBHOOK:
@@ -123,7 +118,6 @@ jobs:
       name: ${{ steps.build.outputs.name }}
     env:
       PYPROJECT_NAME: ${{ inputs.python-package }}
-      DRY_RUN: ${{ inputs.dry-run }}
       PACKAGING: ${{ inputs.packaging }}
       ROOTDIR: ${{ inputs.root-dir }}
       EXTRA_NO_BUILD_ISOLATION_PACKAGES: ${{ inputs.extra-no-build-isolation-packages }}
@@ -200,18 +194,6 @@ jobs:
               fi
             fi
             pip install -e $([[ "$NO_BUILD_ISOLATION" == "true" ]] && echo "--no-build-isolation" || "") .
-          fi
-
-          # If this is a dry run, update the patch version to a random number to upload to test-pypi
-          if [[ "$DRY_RUN" == "true" ]]; then
-            if [[ "$PACKAGING" == "setuptools" || "$PACKAGING" == "uv" ]]; then
-              sed -i "/^PATCH/c\PATCH = $((RANDOM % 9000 + 1000))" "$SRC_DIR${PYPROJECT_NAME//.//}/package_info.py"
-            else
-              RANDOM_DEV=$((RANDOM % 9000 + 1000))
-              pip install hatch
-              VERSION=$(hatch version)$RANDOM_DEV
-              hatch version $VERSION
-            fi
           fi
 
           # Build the wheel
@@ -339,8 +321,51 @@ jobs:
             exit 1
           fi
 
+  validate-wheel:
+    needs: build-wheel
+    runs-on: ubuntu-latest
+    env:
+      PACKAGING: ${{ inputs.packaging }}
+      ROOTDIR: ${{ inputs.root-dir }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          path: ${{ github.run_id }}
+          ref: ${{ inputs.ref }}
+
+      - name: Download wheel
+        uses: actions/download-artifact@v7
+        with:
+          name: pip-wheel-${{ github.run_id }}-${{ inputs.python-package || 'none' }}
+          path: dist/
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install validators
+        run: |
+          python3 -m pip install --upgrade twine==6.0.1 check-wheel-contents check-manifest
+
+      - name: twine check
+        run: |
+          python3 -m twine check dist/*
+
+      - name: check-wheel-contents
+        run: |
+          check-wheel-contents dist/*.whl
+
+      - name: check-manifest
+        if: inputs.packaging == 'setuptools'
+        run: |
+          cd ${{ github.run_id }}
+          cd $ROOTDIR
+          check-manifest -v
+
   publish-wheel:
-    needs: test-wheel
+    needs: [test-wheel, validate-wheel]
     runs-on: ubuntu-latest
     if: |
       inputs.no-publish == false &&
@@ -348,7 +373,7 @@ jobs:
         inputs.skip-test-wheel == false || !cancelled()
       )
     environment:
-      name: ${{ inputs.dry-run && 'public' || 'main' }}
+      name: main
     steps:
       - name: Download wheel
         uses: actions/download-artifact@v7
@@ -356,18 +381,13 @@ jobs:
           name: pip-wheel-${{ github.run_id }}-${{ inputs.python-package || 'none' }}
           path: dist/
 
-      - name: Validate wheel
-        run: |
-          python3 -m pip install --upgrade twine==6.0.1
-          python3 -m twine check dist/*
-
       - name: Release wheel
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          REPOSITORY: ${{ inputs.dry-run && 'testpypi' || 'pypi' }}
         run: |
-          python3 -m twine upload --verbose --skip-existing -u $TWINE_USERNAME -p $TWINE_PASSWORD --repository $REPOSITORY dist/*
+          python3 -m pip install --upgrade twine==6.0.1
+          python3 -m twine upload --verbose --skip-existing -u $TWINE_USERNAME -p $TWINE_PASSWORD --repository pypi dist/*
 
   notify:
     runs-on: ubuntu-latest

--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -367,6 +367,10 @@ jobs:
         run: |
           cd ${{ github.run_id }}
           cd $ROOTDIR
+          if [[ ! -f MANIFEST.in ]]; then
+            echo "::notice::No MANIFEST.in found; skipping check-manifest."
+            exit 0
+          fi
           check-manifest -v
 
   publish-wheel:

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -101,7 +101,9 @@ permissions:
 jobs:
   check-admin-permission:
     runs-on: ubuntu-latest
-    if: inputs.restrict-to-admins == true && inputs.validate-only == false
+    if: inputs.restrict-to-admins == true
+    env:
+      VALIDATE_ONLY: ${{ inputs.validate-only }}
     steps:
       - name: Check if user has admin permission
         uses: actions/github-script@v7
@@ -114,10 +116,16 @@ jobs:
             });
 
             const permission = permissionLevel.permission;
+            const validateOnly = process.env.VALIDATE_ONLY === 'true';
             console.log(`User ${context.actor} has permission: ${permission}`);
 
             if (permission !== 'admin') {
-              core.setFailed(`User ${context.actor} does not have admin permission (has: ${permission}). Only admins can release.`);
+              const msg = `User ${context.actor} does not have admin permission (has: ${permission}). Only admins can release.`;
+              if (validateOnly) {
+                core.notice(`[validate-only] ${msg} — would block real release.`);
+              } else {
+                core.setFailed(msg);
+              }
             }
 
   bump-next-version:

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -393,4 +393,11 @@ jobs:
         if: always() && inputs.validate-only == false && env.TMP_BRANCH != ''
         run: |
           cd ${{ github.run_id }}
-          git push -d origin ${{ env.TMP_BRANCH }} || true
+          if git push -d origin "${TMP_BRANCH}" 2>/tmp/branch-delete.err; then
+            echo "Deleted ${TMP_BRANCH}"
+          else
+            echo "::notice::Branch ${TMP_BRANCH} could not be deleted (likely a deploy-release/* protection rule). It is harmless and can be cleaned up manually if desired."
+            sed 's/^/  /' /tmp/branch-delete.err >&2 || true
+          fi
+        env:
+          TMP_BRANCH: ${{ env.TMP_BRANCH }}

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -83,7 +83,7 @@ on:
         type: string
         required: false
         default: setuptools
-        description: "Packaging tool (supported: setuptools, hatch, uv)."
+        description: "Packaging tool (supported: setuptools, uv)."
       root-dir:
         type: string
         required: false
@@ -238,35 +238,6 @@ jobs:
               sed -i "/^PRE_RELEASE/c\PRE_RELEASE = \"$NEXT_PRERELEASE\"" $PACKAGE_INFO_FILE
               BUMPED_FILES+=("$PACKAGE_INFO_FILE")
 
-              TARGET_NEXT="$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE"
-            elif [[ "$PACKAGING" == "hatch" ]]; then
-              pip install hatch
-              VERSION=$(hatch version)
-              MAJOR=$(echo "$VERSION" | cut -d. -f1)
-              MINOR=$(echo "$VERSION" | cut -d. -f2)
-              PATCH_FULL=$(echo "$VERSION" | cut -d. -f3-)
-              PATCH=$(echo "$PATCH_FULL" | grep -oP '^\d+')
-              PRERELEASE=$(echo "$PATCH_FULL" | grep -oP '(?<=\d)(rc\d+|a\d+)' || true)
-
-              CURRENT_VERSION="$VERSION"
-
-              if [[ "$PRERELEASE" != "" ]]; then
-                if [[ "$PRERELEASE" == rc* ]]; then
-                  NEXT_PATCH=$PATCH
-                  NEXT_PRERELEASE=rc$((${PRERELEASE#rc} + 1))
-                elif [[ "$PRERELEASE" == a* ]]; then
-                  NEXT_PATCH=$PATCH
-                  NEXT_PRERELEASE=a$((${PRERELEASE#a} + 1))
-                else
-                  echo "Unknown pre-release: $PRERELEASE"
-                  exit 1
-                fi
-              else
-                NEXT_PATCH=$((PATCH + 1))
-                NEXT_PRERELEASE=$PRERELEASE
-              fi
-
-              hatch version "$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE"
               TARGET_NEXT="$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE"
             else
               echo "Unsupported packaging: $PACKAGING"

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -1,0 +1,425 @@
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Release: bump version(s)"
+
+defaults:
+  run:
+    shell: bash -x -e -u -o pipefail {0}
+
+on:
+  workflow_call:
+    inputs:
+      release-ref:
+        required: true
+        description: Ref (SHA or branch) to release
+        type: string
+      validate-only:
+        type: boolean
+        required: false
+        default: false
+        description: Compute the bump but do not push the deploy branch, open the PR, wait, merge, or delete. Used by per-PR rehearsals.
+      dry-run:
+        type: boolean
+        required: false
+        default: false
+        description: Compute the bump and exercise the deploy-branch+PR cycle but echo the merge step instead of pushing to the version-bump branch.
+      version-bump-branch:
+        type: string
+        required: false
+        default: main
+        description: Branch to merge the bump commit into.
+      skip-version-bump:
+        type: boolean
+        required: false
+        default: false
+        description: Skip the bump entirely (for dynamic versioning).
+      restrict-to-admins:
+        type: boolean
+        required: false
+        default: true
+        description: Only repository admins may invoke. Always skipped under validate-only.
+      app-id:
+        type: string
+        required: true
+        description: GitHub App ID used to mint the bot token.
+      library-name:
+        type: string
+        required: true
+        description: Human-readable library name used in the bump PR title.
+      bump-targets:
+        type: string
+        required: false
+        default: ""
+        description: |
+          JSON array of bump targets, each `{"python-package": "...", "src-dir": "..."}`.
+          Empty falls back to a single target derived from python-package + has-src-dir.
+          The first target's current version becomes the release-version output.
+      python-package:
+        type: string
+        required: false
+        default: ""
+        description: Single-target back-compat — ignored when bump-targets is non-empty.
+      has-src-dir:
+        type: boolean
+        required: false
+        default: false
+        description: Single-target back-compat — ignored when bump-targets is non-empty.
+      packaging:
+        type: string
+        required: false
+        default: setuptools
+        description: "Packaging tool (supported: setuptools, hatch, uv)."
+      root-dir:
+        type: string
+        required: false
+        default: "./"
+        description: Sub-directory containing the package source(s).
+    secrets:
+      BOT_KEY:
+        required: false
+      SSH_KEY:
+        required: false
+      SSH_PWD:
+        required: false
+    outputs:
+      release-version:
+        description: The version being released (current version of the first bump target, before the bump).
+        value: ${{ jobs.bump-next-version.outputs.release-version }}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-admin-permission:
+    runs-on: ubuntu-latest
+    if: inputs.restrict-to-admins == true && inputs.validate-only == false
+    steps:
+      - name: Check if user has admin permission
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: permissionLevel } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.actor,
+            });
+
+            const permission = permissionLevel.permission;
+            console.log(`User ${context.actor} has permission: ${permission}`);
+
+            if (permission !== 'admin') {
+              core.setFailed(`User ${context.actor} does not have admin permission (has: ${permission}). Only admins can release.`);
+            }
+
+  bump-next-version:
+    runs-on: ubuntu-latest
+    environment: main
+    needs: [check-admin-permission]
+    if: |
+      !inputs.skip-version-bump
+      && (
+        success() || !failure()
+      )
+      && !cancelled()
+    outputs:
+      release-version: ${{ steps.bump.outputs.release-version }}
+      next-version: ${{ steps.bump.outputs.next-version }}
+    env:
+      IS_INERT: ${{ inputs.validate-only || inputs.dry-run }}
+      PACKAGING: ${{ inputs.packaging }}
+      BUMP_TARGETS: ${{ inputs.bump-targets }}
+      FALLBACK_PYPROJECT_NAME: ${{ inputs.python-package }}
+      FALLBACK_SRC_DIR: ${{ inputs.has-src-dir && 'src/' || '' }}
+    steps:
+      - uses: actions/create-github-app-token@v2
+        if: inputs.validate-only == false
+        id: app-token
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.BOT_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          path: ${{ github.run_id }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ inputs.release-ref }}
+
+      - name: Install GPG
+        if: inputs.validate-only == false
+        run: sudo apt-get install -y gnupg2
+
+      - name: Import GPG key (for signing)
+        if: inputs.validate-only == false
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
+        id: gpg-action
+        with:
+          gpg_private_key: ${{ secrets.SSH_KEY }}
+          passphrase: ${{ secrets.SSH_PWD }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          workdir: ${{ github.run_id }}
+
+      - name: Bump version(s)
+        id: bump
+        run: |
+          cd ${{ github.run_id }}
+          cd ${{ inputs.root-dir }}
+
+          # Resolve bump targets. JSON array if provided, else single fallback.
+          if [[ -n "$BUMP_TARGETS" ]]; then
+            TARGETS_JSON="$BUMP_TARGETS"
+          else
+            TARGETS_JSON=$(jq -nc \
+              --arg pkg "$FALLBACK_PYPROJECT_NAME" \
+              --arg src "$FALLBACK_SRC_DIR" \
+              '[{"python-package": $pkg, "src-dir": $src}]')
+          fi
+
+          echo "Resolved targets: $TARGETS_JSON"
+
+          RELEASE_VERSION=""
+          NEXT_VERSION=""
+          BUMPED_FILES=()
+
+          while IFS= read -r TGT; do
+            PYPROJECT_NAME=$(echo "$TGT" | jq -r '."python-package"')
+            SRC_DIR=$(echo "$TGT" | jq -r '."src-dir"')
+            PACKAGE_INFO_FILE="${SRC_DIR}${PYPROJECT_NAME//.//}/package_info.py"
+
+            echo "Bumping $PYPROJECT_NAME at $PACKAGE_INFO_FILE"
+
+            if [[ "$PACKAGING" == "setuptools" || "$PACKAGING" == "uv" ]]; then
+              MAJOR=$(awk '/^MAJOR = /' $PACKAGE_INFO_FILE | awk -F"= " '{print $2}')
+              MINOR=$(awk '/^MINOR = /' $PACKAGE_INFO_FILE | awk -F"= " '{print $2}')
+              PATCH=$(awk '/^PATCH = /' $PACKAGE_INFO_FILE | awk -F"= " '{print $2}')
+              PRERELEASE=$(awk '/^PRE_RELEASE = /' $PACKAGE_INFO_FILE | awk -F"= " '{print $2}' | tr -d '"' | tr -d "'")
+
+              CURRENT_VERSION="$MAJOR.$MINOR.$PATCH$PRERELEASE"
+
+              if [[ "$PRERELEASE" != "" ]]; then
+                if [[ "$PRERELEASE" == *rc* ]]; then
+                  NEXT_PATCH=$PATCH
+                  NEXT_PRERELEASE=rc$((${PRERELEASE#rc} + 1))
+                elif [[ "$PRERELEASE" == *a* ]]; then
+                  NEXT_PATCH=$PATCH
+                  NEXT_PRERELEASE=a$((${PRERELEASE#a} + 1))
+                else
+                  echo "Unknown pre-release: $PRERELEASE"
+                  exit 1
+                fi
+              else
+                NEXT_PATCH=$((${PATCH} + 1))
+                NEXT_PRERELEASE=$PRERELEASE
+              fi
+
+              sed -i "/^PATCH/c\PATCH = $NEXT_PATCH" $PACKAGE_INFO_FILE
+              sed -i "/^PRE_RELEASE/c\PRE_RELEASE = \"$NEXT_PRERELEASE\"" $PACKAGE_INFO_FILE
+              BUMPED_FILES+=("$PACKAGE_INFO_FILE")
+
+              TARGET_NEXT="$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE"
+            elif [[ "$PACKAGING" == "hatch" ]]; then
+              pip install hatch
+              VERSION=$(hatch version)
+              MAJOR=$(echo "$VERSION" | cut -d. -f1)
+              MINOR=$(echo "$VERSION" | cut -d. -f2)
+              PATCH_FULL=$(echo "$VERSION" | cut -d. -f3-)
+              PATCH=$(echo "$PATCH_FULL" | grep -oP '^\d+')
+              PRERELEASE=$(echo "$PATCH_FULL" | grep -oP '(?<=\d)(rc\d+|a\d+)' || true)
+
+              CURRENT_VERSION="$VERSION"
+
+              if [[ "$PRERELEASE" != "" ]]; then
+                if [[ "$PRERELEASE" == rc* ]]; then
+                  NEXT_PATCH=$PATCH
+                  NEXT_PRERELEASE=rc$((${PRERELEASE#rc} + 1))
+                elif [[ "$PRERELEASE" == a* ]]; then
+                  NEXT_PATCH=$PATCH
+                  NEXT_PRERELEASE=a$((${PRERELEASE#a} + 1))
+                else
+                  echo "Unknown pre-release: $PRERELEASE"
+                  exit 1
+                fi
+              else
+                NEXT_PATCH=$((PATCH + 1))
+                NEXT_PRERELEASE=$PRERELEASE
+              fi
+
+              hatch version "$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE"
+              TARGET_NEXT="$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE"
+            else
+              echo "Unsupported packaging: $PACKAGING"
+              exit 1
+            fi
+
+            echo "  $PYPROJECT_NAME: $CURRENT_VERSION -> $TARGET_NEXT"
+
+            if [[ -z "$RELEASE_VERSION" ]]; then
+              RELEASE_VERSION="$CURRENT_VERSION"
+              NEXT_VERSION="$TARGET_NEXT"
+            fi
+          done < <(echo "$TARGETS_JSON" | jq -c '.[]')
+
+          echo "release-version=$RELEASE_VERSION" | tee -a "$GITHUB_OUTPUT"
+          echo "next-version=$NEXT_VERSION" | tee -a "$GITHUB_OUTPUT"
+          printf '%s\n' "${BUMPED_FILES[@]}" > /tmp/bumped-files.txt
+
+      - name: Record computed versions (validate-only)
+        if: inputs.validate-only == true
+        run: |
+          {
+            echo "## Bump rehearsal"
+            echo
+            echo "- release-version (current): \`${{ steps.bump.outputs.release-version }}\`"
+            echo "- next-version (after bump): \`${{ steps.bump.outputs.next-version }}\`"
+            echo
+            echo "validate-only=true → no branch push, no PR, no status-check wait, no merge, no branch delete."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Create and push deployment branch
+        if: inputs.validate-only == false
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          cd ${{ github.run_id }}
+          cd ${{ inputs.root-dir }}
+
+          TMP_BRANCH="deploy-release/$(uuidgen)"
+          git checkout -b "$TMP_BRANCH"
+          # Stage every bumped package_info.py we touched.
+          while IFS= read -r f; do
+            [[ -n "$f" ]] && git add "$f"
+          done < /tmp/bumped-files.txt
+          git commit -sS -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" || echo "No changes to commit"
+          git push -u origin "$TMP_BRANCH"
+          echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
+
+          gh pr create \
+            --base ${{ inputs.version-bump-branch }} \
+            --head $TMP_BRANCH \
+            --title "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" \
+            --body "This is an automated PR to bump ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}."
+
+      - name: Wait for status checks on tmp branch
+        if: inputs.validate-only == false
+        uses: actions/github-script@v8
+        id: wait-status
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const branch = process.env.TMP_BRANCH;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const { data: refData } = await github.rest.git.getRef({
+              owner,
+              repo,
+              ref: `heads/${branch}`,
+            });
+
+            const sha = refData.object.sha;
+
+            console.log(`Polling status for commit SHA: ${sha}`);
+
+            let checksPassed = false;
+            let maxAttempts = 3000;
+            let attempt = 0;
+            const delay = ms => new Promise(res => setTimeout(res, ms));
+
+            while (!checksPassed && attempt < maxAttempts) {
+              attempt++;
+
+              const { data: status } = await github.rest.repos.getCombinedStatusForRef({
+                owner,
+                repo,
+                ref: sha,
+              });
+
+              const { data: checks } = await github.rest.checks.listForRef({
+                owner,
+                repo,
+                ref: sha,
+              });
+
+              const allStatuses = status.statuses;
+              const allChecks = checks.check_runs;
+
+              if (allStatuses.length === 0 && allChecks.length === 0) {
+                console.log(`Attempt ${attempt}: No checks or statuses yet. Waiting...`);
+                await delay(10000);
+                continue;
+              }
+
+              const statusesOk = allStatuses.every(s => s.state === 'success');
+              const checksOk = allChecks.every(c => c.status === 'completed');
+
+              if (statusesOk && checksOk) {
+                console.log('✅ All checks passed.');
+                checksPassed = true;
+                break
+              }
+
+              console.log(`Attempt ${attempt}: Checks not complete yet. Waiting...`);
+              await delay(10000);
+            }
+
+            if (!checksPassed) {
+              core.setFailed('❌ Status checks did not pass in time');
+            }
+
+      - name: Merge into ${{ inputs.version-bump-branch }}
+        if: inputs.validate-only == false
+        run: |
+          cd ${{ github.run_id }}
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          CMD=$(echo -E 'git push origin ${{ inputs.version-bump-branch }}')
+
+          if [[ "$IS_INERT" == "true" ]]; then
+            echo "dry-run enabled, would have run: $CMD"
+          else
+            git fetch origin ${{ inputs.version-bump-branch }}
+            git checkout ${{ inputs.version-bump-branch }}
+            git merge ${{ env.TMP_BRANCH }}
+
+            for attempt in {1..3}; do
+              if eval "$CMD"; then
+                echo "Git push succeeded on attempt $attempt"
+                break
+              else
+                echo "Git push failed on attempt $attempt"
+                if [[ $attempt -lt 3 ]]; then
+                  sleep $((RANDOM % 3 + 1))
+                  git fetch origin ${{ inputs.version-bump-branch }}
+                  git reset --hard origin/${{ inputs.version-bump-branch }}
+                  git merge ${{ env.TMP_BRANCH }}
+                else
+                  echo "Git push failed after 3 attempts"
+                  exit 1
+                fi
+              fi
+            done
+          fi
+
+      - name: Delete ${{ env.TMP_BRANCH }} branch
+        if: always() && inputs.validate-only == false && env.TMP_BRANCH != ''
+        run: |
+          cd ${{ github.run_id }}
+          git push -d origin ${{ env.TMP_BRANCH }} || true

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -52,11 +52,8 @@ on:
         description: Only repository admins may invoke. Always skipped under validate-only.
       app-id:
         type: string
-        required: false
-        default: ""
-        description: |
-          GitHub App ID used to mint the bot token. Empty falls back to PAT
-          (must be passed as the PAT secret) for git push and PR creation.
+        required: true
+        description: GitHub App ID used to mint the bot token for git push, PR creation, and status-check polling.
       library-name:
         type: string
         required: true
@@ -91,14 +88,11 @@ on:
         description: Sub-directory containing the package source(s).
     secrets:
       BOT_KEY:
-        required: false
+        required: true
       SSH_KEY:
-        required: false
+        required: true
       SSH_PWD:
-        required: false
-      PAT:
-        required: false
-        description: Personal access token used for git push + PR creation when app-id is empty.
+        required: true
     outputs:
       release-version:
         description: The version being released (current version of the first bump target, before the bump).
@@ -151,7 +145,7 @@ jobs:
       FALLBACK_SRC_DIR: ${{ inputs.has-src-dir && 'src/' || '' }}
     steps:
       - uses: actions/create-github-app-token@v2
-        if: inputs.validate-only == false && inputs.app-id != ''
+        if: inputs.validate-only == false
         id: app-token
         with:
           app-id: ${{ inputs.app-id }}
@@ -161,17 +155,17 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
-          token: ${{ steps.app-token.outputs.token || secrets.PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ inputs.release-ref }}
 
       - name: Install GPG
-        if: inputs.validate-only == false && inputs.app-id != ''
+        if: inputs.validate-only == false
         run: sudo apt-get install -y gnupg2
 
       - name: Import GPG key (for signing)
-        if: inputs.validate-only == false && inputs.app-id != ''
+        if: inputs.validate-only == false
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
         id: gpg-action
         with:
@@ -271,26 +265,17 @@ jobs:
       - name: Create and push deployment branch
         if: inputs.validate-only == false
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.PAT }}
-          HAS_GPG: ${{ inputs.app-id != '' && 'true' || 'false' }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           cd ${{ github.run_id }}
           cd ${{ inputs.root-dir }}
-
-          if [[ "$HAS_GPG" != "true" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-          fi
 
           TMP_BRANCH="deploy-release/$(uuidgen)"
           git checkout -b "$TMP_BRANCH"
           while IFS= read -r f; do
             [[ -n "$f" ]] && git add "$f"
           done < /tmp/bumped-files.txt
-
-          COMMIT_FLAGS="-s"
-          [[ "$HAS_GPG" == "true" ]] && COMMIT_FLAGS="-sS"
-          git commit $COMMIT_FLAGS -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" || echo "No changes to commit"
+          git commit -sS -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" || echo "No changes to commit"
           git push -u origin "$TMP_BRANCH"
           echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
 
@@ -305,7 +290,7 @@ jobs:
         uses: actions/github-script@v8
         id: wait-status
         with:
-          github-token: ${{ steps.app-token.outputs.token || secrets.PAT || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const branch = process.env.TMP_BRANCH;
             const owner = context.repo.owner;

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -132,7 +132,7 @@ jobs:
 
   bump-next-version:
     runs-on: ubuntu-latest
-    environment: main
+    environment: ${{ inputs.validate-only && 'public' || 'main' }}
     needs: [check-admin-permission]
     if: |
       !inputs.skip-version-bump

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -52,8 +52,11 @@ on:
         description: Only repository admins may invoke. Always skipped under validate-only.
       app-id:
         type: string
-        required: true
-        description: GitHub App ID used to mint the bot token.
+        required: false
+        default: ""
+        description: |
+          GitHub App ID used to mint the bot token. Empty falls back to PAT
+          (must be passed as the PAT secret) for git push and PR creation.
       library-name:
         type: string
         required: true
@@ -93,6 +96,9 @@ on:
         required: false
       SSH_PWD:
         required: false
+      PAT:
+        required: false
+        description: Personal access token used for git push + PR creation when app-id is empty.
     outputs:
       release-version:
         description: The version being released (current version of the first bump target, before the bump).
@@ -145,7 +151,7 @@ jobs:
       FALLBACK_SRC_DIR: ${{ inputs.has-src-dir && 'src/' || '' }}
     steps:
       - uses: actions/create-github-app-token@v2
-        if: inputs.validate-only == false
+        if: inputs.validate-only == false && inputs.app-id != ''
         id: app-token
         with:
           app-id: ${{ inputs.app-id }}
@@ -155,17 +161,17 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
-          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ inputs.release-ref }}
 
       - name: Install GPG
-        if: inputs.validate-only == false
+        if: inputs.validate-only == false && inputs.app-id != ''
         run: sudo apt-get install -y gnupg2
 
       - name: Import GPG key (for signing)
-        if: inputs.validate-only == false
+        if: inputs.validate-only == false && inputs.app-id != ''
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
         id: gpg-action
         with:
@@ -294,18 +300,26 @@ jobs:
       - name: Create and push deployment branch
         if: inputs.validate-only == false
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || secrets.PAT }}
+          HAS_GPG: ${{ inputs.app-id != '' && 'true' || 'false' }}
         run: |
           cd ${{ github.run_id }}
           cd ${{ inputs.root-dir }}
 
+          if [[ "$HAS_GPG" != "true" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+          fi
+
           TMP_BRANCH="deploy-release/$(uuidgen)"
           git checkout -b "$TMP_BRANCH"
-          # Stage every bumped package_info.py we touched.
           while IFS= read -r f; do
             [[ -n "$f" ]] && git add "$f"
           done < /tmp/bumped-files.txt
-          git commit -sS -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" || echo "No changes to commit"
+
+          COMMIT_FLAGS="-s"
+          [[ "$HAS_GPG" == "true" ]] && COMMIT_FLAGS="-sS"
+          git commit $COMMIT_FLAGS -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" || echo "No changes to commit"
           git push -u origin "$TMP_BRANCH"
           echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
 
@@ -320,7 +334,7 @@ jobs:
         uses: actions/github-script@v8
         id: wait-status
         with:
-          github-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token || secrets.PAT || secrets.GITHUB_TOKEN }}
           script: |
             const branch = process.env.TMP_BRANCH;
             const owner = context.repo.owner;

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -89,10 +89,6 @@ on:
     secrets:
       BOT_KEY:
         required: true
-      SSH_KEY:
-        required: false
-      SSH_PWD:
-        required: false
     outputs:
       release-version:
         description: The version being released (current version of the first bump target, before the bump).
@@ -159,33 +155,6 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ inputs.release-ref }}
-
-      - name: Detect GPG key
-        id: gpg
-        env:
-          SSH_KEY: ${{ secrets.SSH_KEY }}
-        run: |
-          if [[ -z "$SSH_KEY" ]]; then
-            echo "configured=false" | tee -a "$GITHUB_OUTPUT"
-            echo "::notice::No GPG key (SSH_KEY) configured; commits will be -s only (signed-off, unsigned)."
-          else
-            echo "configured=true" | tee -a "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install GPG
-        if: inputs.validate-only == false && steps.gpg.outputs.configured == 'true'
-        run: sudo apt-get install -y gnupg2
-
-      - name: Import GPG key (for signing)
-        if: inputs.validate-only == false && steps.gpg.outputs.configured == 'true'
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
-        id: gpg-action
-        with:
-          gpg_private_key: ${{ secrets.SSH_KEY }}
-          passphrase: ${{ secrets.SSH_PWD }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          workdir: ${{ github.run_id }}
 
       - name: Bump version(s)
         id: bump
@@ -278,15 +247,12 @@ jobs:
         if: inputs.validate-only == false
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          HAS_GPG: ${{ steps.gpg.outputs.configured }}
         run: |
           cd ${{ github.run_id }}
           cd ${{ inputs.root-dir }}
 
-          if [[ "$HAS_GPG" != "true" ]]; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
           TMP_BRANCH="deploy-release/$(uuidgen)"
           git checkout -b "$TMP_BRANCH"
@@ -294,9 +260,7 @@ jobs:
             [[ -n "$f" ]] && git add "$f"
           done < /tmp/bumped-files.txt
 
-          COMMIT_FLAGS="-s"
-          [[ "$HAS_GPG" == "true" ]] && COMMIT_FLAGS="-sS"
-          git commit $COMMIT_FLAGS -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" || echo "No changes to commit"
+          git commit -s -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" || echo "No changes to commit"
           git push -u origin "$TMP_BRANCH"
           echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
 

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -393,11 +393,4 @@ jobs:
         if: always() && inputs.validate-only == false && env.TMP_BRANCH != ''
         run: |
           cd ${{ github.run_id }}
-          if git push -d origin "${TMP_BRANCH}" 2>/tmp/branch-delete.err; then
-            echo "Deleted ${TMP_BRANCH}"
-          else
-            echo "::notice::Branch ${TMP_BRANCH} could not be deleted (likely a deploy-release/* protection rule). It is harmless and can be cleaned up manually if desired."
-            sed 's/^/  /' /tmp/branch-delete.err >&2 || true
-          fi
-        env:
-          TMP_BRANCH: ${{ env.TMP_BRANCH }}
+          git push -d origin ${{ env.TMP_BRANCH }} || true

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -268,7 +268,7 @@ jobs:
             [[ -n "$f" ]] && git add "$f"
           done < /tmp/bumped-files.txt
 
-          git commit -s -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" || echo "No changes to commit"
+          git commit -s -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }} [skip ci]" || echo "No changes to commit"
           git push -u origin "$TMP_BRANCH"
           echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
 
@@ -296,6 +296,14 @@ jobs:
             });
 
             const sha = refData.object.sha;
+
+            const { data: commit } = await github.rest.git.getCommit({ owner, repo, commit_sha: sha });
+            const message = commit.message || '';
+            const skipMarkers = ['[skip ci]', '[ci skip]', '[no ci]', '[skip actions]', '[actions skip]'];
+            if (skipMarkers.some(m => message.includes(m))) {
+              console.log(`✅ Bump commit carries a skip-CI marker; no checks will register — short-circuiting.`);
+              return;
+            }
 
             console.log(`Polling status for commit SHA: ${sha}`);
 

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -90,9 +90,9 @@ on:
       BOT_KEY:
         required: true
       SSH_KEY:
-        required: true
+        required: false
       SSH_PWD:
-        required: true
+        required: false
     outputs:
       release-version:
         description: The version being released (current version of the first bump target, before the bump).
@@ -160,12 +160,24 @@ jobs:
           fetch-tags: true
           ref: ${{ inputs.release-ref }}
 
+      - name: Detect GPG key
+        id: gpg
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+        run: |
+          if [[ -z "$SSH_KEY" ]]; then
+            echo "configured=false" | tee -a "$GITHUB_OUTPUT"
+            echo "::notice::No GPG key (SSH_KEY) configured; commits will be -s only (signed-off, unsigned)."
+          else
+            echo "configured=true" | tee -a "$GITHUB_OUTPUT"
+          fi
+
       - name: Install GPG
-        if: inputs.validate-only == false
+        if: inputs.validate-only == false && steps.gpg.outputs.configured == 'true'
         run: sudo apt-get install -y gnupg2
 
       - name: Import GPG key (for signing)
-        if: inputs.validate-only == false
+        if: inputs.validate-only == false && steps.gpg.outputs.configured == 'true'
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
         id: gpg-action
         with:
@@ -266,16 +278,25 @@ jobs:
         if: inputs.validate-only == false
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HAS_GPG: ${{ steps.gpg.outputs.configured }}
         run: |
           cd ${{ github.run_id }}
           cd ${{ inputs.root-dir }}
+
+          if [[ "$HAS_GPG" != "true" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+          fi
 
           TMP_BRANCH="deploy-release/$(uuidgen)"
           git checkout -b "$TMP_BRANCH"
           while IFS= read -r f; do
             [[ -n "$f" ]] && git add "$f"
           done < /tmp/bumped-files.txt
-          git commit -sS -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" || echo "No changes to commit"
+
+          COMMIT_FLAGS="-s"
+          [[ "$HAS_GPG" == "true" ]] && COMMIT_FLAGS="-sS"
+          git commit $COMMIT_FLAGS -m "beep boop 🤖: Bumping ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}" || echo "No changes to commit"
           git push -u origin "$TMP_BRANCH"
           echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
 

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -109,6 +109,16 @@ on:
         description: pip-installable requirements.txt used to install docs deps (instead of uv sync --only-group docs).
         type: string
         default: ""
+      docs-directory:
+        required: false
+        description: Sphinx docs directory (where conf.py lives). Defaults to `docs`; override for repos like NeMo that keep conf.py under `docs/source/`.
+        type: string
+        default: "docs"
+      docs-fail-on-warning:
+        required: false
+        description: Fail the docs build on Sphinx warnings.
+        type: boolean
+        default: true
       notify-emails:
         required: false
         type: string
@@ -294,6 +304,8 @@ jobs:
       ref: ${{ (inputs.validate-only || inputs.dry-run) && inputs.release-ref || format('{0}v{1}', inputs.gh-release-tag-prefix || '', inputs.release-version) }}
       root-dir: ${{ inputs.docs-root-dir != '' && inputs.docs-root-dir || inputs.root-dir }}
       requirements-file: ${{ inputs.docs-requirements-file }}
+      docs-directory: ${{ inputs.docs-directory }}
+      fail-on-warning: ${{ inputs.docs-fail-on-warning }}
 
   publish-docs:
     needs: [create-gh-release, build-docs]

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -271,13 +271,12 @@ jobs:
   publish-docs:
     needs: [create-gh-release, build-docs]
     runs-on: ubuntu-latest
-    environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
+    environment: ${{ (inputs.validate-only || inputs.dry-run) && 'public' || 'main' }}
     if: |
       (
         success() || !failure()
       )
       && inputs.publish-docs == true
-      && inputs.validate-only == false
       && !cancelled()
     env:
       VERSION: ${{ inputs.release-version }}
@@ -301,7 +300,7 @@ jobs:
       - name: Publish documentation
         uses: ./FW-CI-templates/.github/actions/publish-docs
         with:
-          dry-run: ${{ inputs.dry-run }}
+          dry-run: ${{ inputs.dry-run || inputs.validate-only }}
           artifacts-name: docs-html
           artifacts-path: _build/html
           emails-csv: ${{ inputs.notify-emails && format('{0},{1}', vars.docs_release_emails, inputs.notify-emails) || vars.docs_release_emails }}
@@ -327,15 +326,14 @@ jobs:
       (
         success() || !failure()
       )
-      && inputs.validate-only == false
       && !cancelled()
-    environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
+    environment: ${{ (inputs.validate-only || inputs.dry-run) && 'public' || 'main' }}
     env:
       GH_URL: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.gh-release-tag-prefix || '' }}v${{ inputs.release-version }}
       PROJECT_NAME: ${{ inputs.library-name }}
       VERSION: ${{ inputs.release-version }}
       PYPI_NAME: ${{ inputs.pypi-name }}
-      DRY_RUN: ${{ inputs.dry-run }}
+      IS_INERT: ${{ inputs.validate-only || inputs.dry-run }}
     steps:
       - name: Detect webhook
         id: webhook
@@ -354,7 +352,7 @@ jobs:
         id: msg
         run: |
           PREFIX=""
-          [[ "$DRY_RUN" == "true" ]] && PREFIX="This is a dry-run, nothing actually happened: "
+          [[ "$IS_INERT" == "true" ]] && PREFIX="This is a dry-run, nothing actually happened: "
 
           {
             echo "message<<EOF"
@@ -367,8 +365,19 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Render assembled Slack message to step summary (inert)
+        if: env.IS_INERT == 'true' && steps.webhook.outputs.configured == 'true'
+        run: |
+          {
+            echo "## Slack notify (inert)"
+            echo
+            echo '```'
+            echo "${{ steps.msg.outputs.message }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout
-        if: steps.webhook.outputs.configured == 'true'
+        if: env.IS_INERT == 'false' && steps.webhook.outputs.configured == 'true'
         uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
@@ -376,7 +385,7 @@ jobs:
           path: send-slack-alert
 
       - name: Send Slack alert
-        if: steps.webhook.outputs.configured == 'true'
+        if: env.IS_INERT == 'false' && steps.webhook.outputs.configured == 'true'
         uses: ./send-slack-alert/.github/actions/send-slack-alert
         with:
           message: ${{ steps.msg.outputs.message }}

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -1,0 +1,347 @@
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Release: finalize (GH release + docs + notify)"
+
+defaults:
+  run:
+    shell: bash -x -e -u -o pipefail {0}
+
+on:
+  workflow_call:
+    inputs:
+      release-ref:
+        required: true
+        type: string
+      release-version:
+        required: true
+        type: string
+        description: The version being released (typically the bump output's release-version).
+      library-name:
+        required: true
+        type: string
+      pypi-name:
+        required: false
+        type: string
+        default: ""
+        description: PyPI project name (only used to build the Slack notification URL). Empty hides the PyPi link.
+      validate-only:
+        required: false
+        type: boolean
+        default: false
+      dry-run:
+        required: false
+        type: boolean
+        default: false
+      create-gh-release:
+        required: false
+        type: boolean
+        default: true
+      gh-release-tag-prefix:
+        required: false
+        type: string
+        default: ""
+      gh-release-use-changelog-builder:
+        required: false
+        type: boolean
+        default: false
+      gh-release-changelog-config:
+        required: false
+        type: string
+        default: ".github/workflows/config/changelog-config.json"
+      gh-release-changelog-included-paths:
+        required: false
+        type: string
+        default: ""
+      gh-release-from-tag:
+        required: false
+        type: string
+        default: ""
+      gh-release-changelog-mode:
+        required: false
+        type: string
+        default: PR
+      publish-docs:
+        required: false
+        type: boolean
+        default: true
+      docs-target-path:
+        required: false
+        type: string
+        default: ""
+      docs-project-type:
+        required: false
+        type: string
+        default: single-docset
+      notify-emails:
+        required: false
+        type: string
+        default: ""
+      root-dir:
+        required: false
+        type: string
+        default: "./"
+    secrets:
+      PAT:
+        required: false
+      SLACK_WEBHOOK:
+        required: false
+      SLACK_WEBHOOK_ADMIN:
+        required: false
+      AWS_ASSUME_ROLE_ARN:
+        required: false
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+      AKAMAI_HOST:
+        required: false
+      AKAMAI_CLIENT_TOKEN:
+        required: false
+      AKAMAI_CLIENT_SECRET:
+        required: false
+      AKAMAI_ACCESS_TOKEN:
+        required: false
+      S3_BUCKET_NAME:
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  create-gh-release:
+    runs-on: ubuntu-latest
+    environment: ${{ (inputs.validate-only || inputs.dry-run) && 'public' || 'main' }}
+    if: |
+      inputs.create-gh-release == true
+      && !cancelled()
+    outputs:
+      is-release-candidate: ${{ steps.version-number.outputs.is-release-candidate }}
+    env:
+      REPOSITORY: ${{ github.repository }}
+      PROJECT_NAME: ${{ inputs.library-name }}
+      VERSION: ${{ inputs.release-version }}
+      TAG_PREFIX: ${{ inputs.gh-release-tag-prefix || '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          path: ${{ github.run_id }}
+          ref: ${{ inputs.release-ref }}
+          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Determine fromTag for changelog
+        id: determine-from-tag
+        if: inputs.gh-release-use-changelog-builder == true
+        run: |
+          cd ${{ github.run_id }}
+
+          if [[ -n "${{ inputs.gh-release-from-tag }}" ]]; then
+            FROM_TAG="${{ inputs.gh-release-from-tag }}"
+            echo "Using provided fromTag: $FROM_TAG"
+          else
+            if [[ -n "$TAG_PREFIX" ]]; then
+              FROM_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname 2>/dev/null | head -n1 || echo "")
+            else
+              FROM_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+            fi
+            if [[ -z "$FROM_TAG" ]]; then
+              echo "No previous tags found, leaving fromTag empty"
+            else
+              echo "Auto-detected most recent tag: $FROM_TAG"
+            fi
+          fi
+
+          echo "from-tag=$FROM_TAG" >> $GITHUB_OUTPUT
+
+      - name: Build Changelog
+        id: build-changelog
+        if: inputs.gh-release-use-changelog-builder == true
+        uses: mikepenz/release-changelog-builder-action@v6.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+        with:
+          configuration: ${{ github.run_id }}/${{ inputs.gh-release-changelog-config }}
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          ignorePreReleases: "false"
+          failOnError: "false"
+          fromTag: ${{ steps.determine-from-tag.outputs.from-tag }}
+          toTag: ${{ inputs.release-ref }}
+          mode: ${{ inputs.gh-release-changelog-mode }}
+          includeOnlyPaths: ${{ inputs.gh-release-changelog-included-paths }}
+
+      - name: Create release
+        id: version-number
+        env:
+          SHA: ${{ inputs.release-ref }}
+          GH_TOKEN: ${{ secrets.PAT || '' }}
+          IS_INERT: ${{ inputs.validate-only || inputs.dry-run }}
+          BUILT_CHANGELOG: ${{ steps.build-changelog.outputs.changelog }}
+        run: |
+          cd ${{ github.run_id }}
+          cd ${{ inputs.root-dir }}
+
+          IS_RELEASE_CANDIDATE=$([[ "$VERSION" == *rc* ]] && echo "true" || echo "false")
+          IS_ALPHA=$([[ "$VERSION" == *a* ]] && echo "true" || echo "false")
+          IS_PRERELEASE=$([[ "$IS_RELEASE_CANDIDATE" == "true" || "$IS_ALPHA" == "true" ]] && echo "true" || echo "false")
+          NAME="NVIDIA $PROJECT_NAME ${VERSION}"
+
+          if [[ -n "$BUILT_CHANGELOG" ]]; then
+            CHANGELOG="$BUILT_CHANGELOG"
+          elif [[ "$IS_RELEASE_CANDIDATE" == "true" ]]; then
+            DATE=$(date +"%Y-%m-%d")
+            CHANGELOG="Prerelease: $NAME ($DATE)"
+          elif [[ -f CHANGELOG.md ]]; then
+            CHANGELOG=$(awk '/^## '"$NAME"'/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md)
+            CHANGELOG=$(echo "$CHANGELOG" | sed '/./,$!d' | sed ':a;N;$!ba;s/\n$//')
+          else
+            CHANGELOG="Release: $NAME"
+          fi
+
+          echo "is-release-candidate=$IS_RELEASE_CANDIDATE" | tee -a "$GITHUB_OUTPUT"
+
+          PAYLOAD=$(jq -nc \
+                      --arg TAG_NAME "${TAG_PREFIX}v${VERSION}" \
+                      --arg CI_COMMIT_BRANCH "$SHA" \
+                      --arg NAME "$NAME" \
+                      --arg BODY "$CHANGELOG" \
+                      --argjson PRERELEASE "$IS_PRERELEASE" \
+                      '{
+                        "tag_name": $TAG_NAME,
+                        "target_commitish": $CI_COMMIT_BRANCH,
+                        "name": $NAME,
+                        "body": $BODY,
+                        "draft": false,
+                        "prerelease": $PRERELEASE,
+                      }'
+                  )
+          echo -E "$PAYLOAD" > payload.txt
+
+          CMD=$(echo -E 'curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer '"$GH_TOKEN"'" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/'"$REPOSITORY"'/releases \
+            -d @payload.txt
+          ')
+
+          if [[ "$IS_INERT" == "true" ]]; then
+            echo -E "$CMD"
+          else
+            eval "$CMD"
+          fi
+
+  build-docs:
+    needs: [create-gh-release]
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.72.0
+    if: |
+      (
+        success() || !failure()
+      )
+      && (inputs.publish-docs == true || inputs.validate-only == true)
+      && !cancelled()
+    with:
+      ref: ${{ (inputs.validate-only || inputs.dry-run) && inputs.release-ref || format('{0}v{1}', inputs.gh-release-tag-prefix || '', inputs.release-version) }}
+
+  publish-docs:
+    needs: [create-gh-release, build-docs]
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
+    if: |
+      (
+        success() || !failure()
+      )
+      && inputs.publish-docs == true
+      && inputs.validate-only == false
+      && !cancelled()
+    env:
+      VERSION: ${{ inputs.release-version }}
+      LIBRARY_NAME: ${{ inputs.library-name }}
+      S3_TARGET_PATH: ${{ inputs.docs-target-path }}
+    steps:
+      - name: Checkout FW-CI-templates
+        uses: actions/checkout@v6
+        with:
+          repository: NVIDIA-NeMo/FW-CI-templates
+          ref: v0.72.0
+          path: FW-CI-templates
+
+      - name: Generate request name
+        id: request-name
+        shell: bash
+        run: |
+          REQUEST_NAME="${S3_TARGET_PATH//\//-}-publish-docs-${{ github.run_id }}"
+          echo "value=${REQUEST_NAME}" >> $GITHUB_OUTPUT
+
+      - name: Publish documentation
+        uses: ./FW-CI-templates/.github/actions/publish-docs
+        with:
+          dry-run: ${{ inputs.dry-run }}
+          artifacts-name: docs-html
+          artifacts-path: _build/html
+          emails-csv: ${{ inputs.notify-emails && format('{0},{1}', vars.docs_release_emails, inputs.notify-emails) || vars.docs_release_emails }}
+          overwrite-latest-on-tag: true
+          docs-version-override: ${{ env.VERSION }}
+          project-type: ${{ inputs.docs-project-type }}
+          request-name: ${{ steps.request-name.outputs.value }}
+          aws-region: ${{ vars.DOCS_AWS_REGION }}
+          aws-role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          akamai-host: ${{ secrets.AKAMAI_HOST }}
+          akamai-client-token: ${{ secrets.AKAMAI_CLIENT_TOKEN }}
+          akamai-client-secret: ${{ secrets.AKAMAI_CLIENT_SECRET }}
+          akamai-access-token: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
+          s3-target-root: ${{ secrets.S3_BUCKET_NAME }}
+          s3-target-path: ${{ inputs.docs-target-path }}
+
+  notify:
+    needs: [create-gh-release]
+    runs-on: ubuntu-latest
+    if: |
+      (
+        success() || !failure()
+      )
+      && inputs.validate-only == false
+      && !cancelled()
+    environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
+    env:
+      GH_URL: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.gh-release-tag-prefix || '' }}v${{ inputs.release-version }}
+      PYPI_URL: https://${{ inputs.dry-run == true && 'test.' || '' }}pypi.org/project/${{ inputs.pypi-name }}/${{ inputs.release-version }}/
+      PROJECT_NAME: ${{ inputs.library-name }}
+      VERSION: ${{ inputs.release-version }}
+      PYPI_NAME: ${{ inputs.pypi-name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          repository: NVIDIA-NeMo/FW-CI-templates
+          ref: v0.17.0
+          path: send-slack-alert
+
+      - name: Send Slack alert
+        uses: ./send-slack-alert/.github/actions/send-slack-alert
+        env:
+          MESSAGE: |
+            ${{ inputs.dry-run == true && 'This is a dry-run, nothing actually happened: ' || '' }}We have released `${{ env.VERSION }}` of `NVIDIA ${{ env.PROJECT_NAME }}` 🚀✨🎉
+
+            • <${{ env.GH_URL }}|GitHub release>${{ env.PYPI_NAME != '' && format('{0}            • <{1}|PyPi release>', '\n', env.PYPI_URL) || '' }}
+
+        with:
+          message: ${{ env.MESSAGE }}
+          webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -92,9 +92,13 @@ on:
         required: false
         type: string
         default: "./"
+      app-id:
+        type: string
+        required: true
+        description: GitHub App ID for minting the bot token used by create-gh-release.
     secrets:
-      PAT:
-        required: false
+      BOT_KEY:
+        required: true
       SLACK_WEBHOOK:
         required: false
       SLACK_WEBHOOK_ADMIN:
@@ -134,12 +138,18 @@ jobs:
       VERSION: ${{ inputs.release-version }}
       TAG_PREFIX: ${{ inputs.gh-release-tag-prefix || '' }}
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ inputs.app-id }}
+          private-key: ${{ secrets.BOT_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
           ref: ${{ inputs.release-ref }}
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -172,7 +182,7 @@ jobs:
         if: inputs.gh-release-use-changelog-builder == true
         uses: mikepenz/release-changelog-builder-action@v6.1.0
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           configuration: ${{ github.run_id }}/${{ inputs.gh-release-changelog-config }}
           owner: ${{ github.repository_owner }}
@@ -188,7 +198,7 @@ jobs:
         id: version-number
         env:
           SHA: ${{ inputs.release-ref }}
-          GH_TOKEN: ${{ secrets.PAT || '' }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           IS_INERT: ${{ inputs.validate-only || inputs.dry-run }}
           BUILT_CHANGELOG: ${{ steps.build-changelog.outputs.changelog }}
         run: |

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -413,12 +413,14 @@ jobs:
 
       - name: Render assembled Slack message to step summary (validate-only)
         if: env.IS_VALIDATE_ONLY == 'true' && steps.webhook.outputs.configured == 'true'
+        env:
+          MSG: ${{ steps.msg.outputs.message }}
         run: |
           {
             echo "## Slack notify (validate-only — not posted)"
             echo
             echo '```'
-            echo "${{ steps.msg.outputs.message }}"
+            printf '%s\n' "$MSG"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -273,7 +273,7 @@ jobs:
 
   build-docs:
     needs: [create-gh-release]
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.94.1
+    uses: ./.github/workflows/_build_docs.yml
     if: |
       (
         success() || !failure()
@@ -282,6 +282,7 @@ jobs:
       && !cancelled()
     with:
       ref: ${{ (inputs.validate-only || inputs.dry-run) && inputs.release-ref || format('{0}v{1}', inputs.gh-release-tag-prefix || '', inputs.release-version) }}
+      root-dir: ${{ inputs.root-dir }}
 
   publish-docs:
     needs: [create-gh-release, build-docs]

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -119,6 +119,11 @@ on:
         description: Fail the docs build on Sphinx warnings.
         type: boolean
         default: true
+      docs-skip-linkcheck:
+        required: false
+        description: Skip Sphinx linkcheck. Use until the repo curates a `broken_links_false_positives.json`.
+        type: boolean
+        default: false
       notify-emails:
         required: false
         type: string
@@ -306,6 +311,7 @@ jobs:
       requirements-file: ${{ inputs.docs-requirements-file }}
       docs-directory: ${{ inputs.docs-directory }}
       fail-on-warning: ${{ inputs.docs-fail-on-warning }}
+      skip-linkcheck: ${{ inputs.docs-skip-linkcheck }}
 
   publish-docs:
     needs: [create-gh-release, build-docs]

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -374,7 +374,7 @@ jobs:
         success() || !failure()
       )
       && !cancelled()
-    environment: ${{ inputs.validate-only && 'public' || 'main' }}
+    environment: ${{ (inputs.validate-only || inputs.dry-run) && 'public' || 'main' }}
     env:
       GH_URL: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.gh-release-tag-prefix || '' }}v${{ inputs.release-version }}
       PROJECT_NAME: ${{ inputs.library-name }}

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -332,10 +332,10 @@ jobs:
     environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
     env:
       GH_URL: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.gh-release-tag-prefix || '' }}v${{ inputs.release-version }}
-      PYPI_URL: https://${{ inputs.dry-run == true && 'test.' || '' }}pypi.org/project/${{ inputs.pypi-name }}/${{ inputs.release-version }}/
       PROJECT_NAME: ${{ inputs.library-name }}
       VERSION: ${{ inputs.release-version }}
       PYPI_NAME: ${{ inputs.pypi-name }}
+      DRY_RUN: ${{ inputs.dry-run }}
     steps:
       - name: Detect webhook
         id: webhook
@@ -349,6 +349,24 @@ jobs:
             echo "configured=true" | tee -a "$GITHUB_OUTPUT"
           fi
 
+      - name: Build Slack message
+        if: steps.webhook.outputs.configured == 'true'
+        id: msg
+        run: |
+          PREFIX=""
+          [[ "$DRY_RUN" == "true" ]] && PREFIX="This is a dry-run, nothing actually happened: "
+
+          {
+            echo "message<<EOF"
+            echo "${PREFIX}We have released \`${VERSION}\` of \`NVIDIA ${PROJECT_NAME}\` 🚀✨🎉"
+            echo
+            echo "• <${GH_URL}|GitHub release>"
+            if [[ -n "$PYPI_NAME" ]]; then
+              echo "• <https://pypi.org/project/${PYPI_NAME}/${VERSION}/|PyPi release>"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         if: steps.webhook.outputs.configured == 'true'
         uses: actions/checkout@v6
@@ -360,13 +378,6 @@ jobs:
       - name: Send Slack alert
         if: steps.webhook.outputs.configured == 'true'
         uses: ./send-slack-alert/.github/actions/send-slack-alert
-        env:
-          MESSAGE: |
-            ${{ inputs.dry-run == true && 'This is a dry-run, nothing actually happened: ' || '' }}We have released `${{ env.VERSION }}` of `NVIDIA ${{ env.PROJECT_NAME }}` 🚀✨🎉
-
-            • <${{ env.GH_URL }}|GitHub release>
-            • <${{ env.PYPI_URL }}|PyPi release>
-
         with:
-          message: ${{ env.MESSAGE }}
+          message: ${{ steps.msg.outputs.message }}
           webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -340,7 +340,8 @@ jobs:
           MESSAGE: |
             ${{ inputs.dry-run == true && 'This is a dry-run, nothing actually happened: ' || '' }}We have released `${{ env.VERSION }}` of `NVIDIA ${{ env.PROJECT_NAME }}` 🚀✨🎉
 
-            • <${{ env.GH_URL }}|GitHub release>${{ env.PYPI_NAME != '' && format('{0}            • <{1}|PyPi release>', '\n', env.PYPI_URL) || '' }}
+            • <${{ env.GH_URL }}|GitHub release>
+            • <${{ env.PYPI_URL }}|PyPi release>
 
         with:
           message: ${{ env.MESSAGE }}

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -253,7 +253,7 @@ jobs:
       (
         success() || !failure()
       )
-      && (inputs.publish-docs == true || inputs.validate-only == true)
+      && inputs.publish-docs == true
       && !cancelled()
     with:
       ref: ${{ (inputs.validate-only || inputs.dry-run) && inputs.release-ref || format('{0}v{1}', inputs.gh-release-tag-prefix || '', inputs.release-version) }}

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -99,6 +99,16 @@ on:
         description: Skip the publish step unless the workflow is running on a version tag (useful when calling release-docs from non-tag refs).
         type: boolean
         default: false
+      docs-root-dir:
+        required: false
+        description: Sub-directory containing the docs source's pyproject.toml. Defaults to root-dir; override for monorepos whose docs live at repo root.
+        type: string
+        default: ""
+      docs-requirements-file:
+        required: false
+        description: pip-installable requirements.txt used to install docs deps (instead of uv sync --only-group docs).
+        type: string
+        default: ""
       notify-emails:
         required: false
         type: string
@@ -282,7 +292,8 @@ jobs:
       && !cancelled()
     with:
       ref: ${{ (inputs.validate-only || inputs.dry-run) && inputs.release-ref || format('{0}v{1}', inputs.gh-release-tag-prefix || '', inputs.release-version) }}
-      root-dir: ${{ inputs.root-dir }}
+      root-dir: ${{ inputs.docs-root-dir != '' && inputs.docs-root-dir || inputs.root-dir }}
+      requirements-file: ${{ inputs.docs-requirements-file }}
 
   publish-docs:
     needs: [create-gh-release, build-docs]

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -327,7 +327,20 @@ jobs:
       VERSION: ${{ inputs.release-version }}
       PYPI_NAME: ${{ inputs.pypi-name }}
     steps:
+      - name: Detect webhook
+        id: webhook
+        env:
+          WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: |
+          if [[ -z "$WEBHOOK" ]]; then
+            echo "configured=false" | tee -a "$GITHUB_OUTPUT"
+            echo "::notice::SLACK_WEBHOOK not configured; skipping Slack notify."
+          else
+            echo "configured=true" | tee -a "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout
+        if: steps.webhook.outputs.configured == 'true'
         uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
@@ -335,6 +348,7 @@ jobs:
           path: send-slack-alert
 
       - name: Send Slack alert
+        if: steps.webhook.outputs.configured == 'true'
         uses: ./send-slack-alert/.github/actions/send-slack-alert
         env:
           MESSAGE: |

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -84,6 +84,21 @@ on:
         required: false
         type: string
         default: single-docset
+      publish-as-latest:
+        required: false
+        description: Overwrite the "latest" docs alias when publishing on a version tag.
+        type: boolean
+        default: true
+      update-version-picker:
+        required: false
+        description: Refresh the in-page docs version-picker after publishing.
+        type: boolean
+        default: true
+      run-on-version-tag-only:
+        required: false
+        description: Skip the publish step unless the workflow is running on a version tag (useful when calling release-docs from non-tag refs).
+        type: boolean
+        default: false
       notify-emails:
         required: false
         type: string
@@ -258,7 +273,7 @@ jobs:
 
   build-docs:
     needs: [create-gh-release]
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.72.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.94.1
     if: |
       (
         success() || !failure()
@@ -287,7 +302,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.72.0
+          ref: v0.94.1
           path: FW-CI-templates
 
       - name: Generate request name
@@ -304,9 +319,11 @@ jobs:
           artifacts-name: docs-html
           artifacts-path: _build/html
           emails-csv: ${{ inputs.notify-emails && format('{0},{1}', vars.docs_release_emails, inputs.notify-emails) || vars.docs_release_emails }}
-          overwrite-latest-on-tag: true
-          docs-version-override: ${{ env.VERSION }}
+          overwrite-latest-on-tag: ${{ inputs.publish-as-latest }}
+          update-version-picker: ${{ inputs.update-version-picker }}
+          run-on-version-tag-only: ${{ inputs.run-on-version-tag-only }}
           project-type: ${{ inputs.docs-project-type }}
+          docs-version-override: ${{ env.VERSION }}
           request-name: ${{ steps.request-name.outputs.value }}
           aws-region: ${{ vars.DOCS_AWS_REGION }}
           aws-role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -139,8 +139,6 @@ on:
     secrets:
       BOT_KEY:
         required: true
-      SLACK_WEBHOOK:
-        required: false
       SLACK_WEBHOOK_ADMIN:
         required: false
       AWS_ASSUME_ROLE_ARN:

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -356,13 +356,14 @@ jobs:
         success() || !failure()
       )
       && !cancelled()
-    environment: ${{ (inputs.validate-only || inputs.dry-run) && 'public' || 'main' }}
+    environment: ${{ inputs.validate-only && 'public' || 'main' }}
     env:
       GH_URL: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.gh-release-tag-prefix || '' }}v${{ inputs.release-version }}
       PROJECT_NAME: ${{ inputs.library-name }}
       VERSION: ${{ inputs.release-version }}
       PYPI_NAME: ${{ inputs.pypi-name }}
-      IS_INERT: ${{ inputs.validate-only || inputs.dry-run }}
+      IS_VALIDATE_ONLY: ${{ inputs.validate-only }}
+      IS_DRY_RUN: ${{ inputs.dry-run }}
     steps:
       - name: Detect webhook
         id: webhook
@@ -381,7 +382,7 @@ jobs:
         id: msg
         run: |
           PREFIX=""
-          [[ "$IS_INERT" == "true" ]] && PREFIX="This is a dry-run, nothing actually happened: "
+          [[ "$IS_DRY_RUN" == "true" ]] && PREFIX="This is a dry-run, nothing actually happened: "
 
           {
             echo "message<<EOF"
@@ -394,11 +395,11 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Render assembled Slack message to step summary (inert)
-        if: env.IS_INERT == 'true' && steps.webhook.outputs.configured == 'true'
+      - name: Render assembled Slack message to step summary (validate-only)
+        if: env.IS_VALIDATE_ONLY == 'true' && steps.webhook.outputs.configured == 'true'
         run: |
           {
-            echo "## Slack notify (inert)"
+            echo "## Slack notify (validate-only — not posted)"
             echo
             echo '```'
             echo "${{ steps.msg.outputs.message }}"
@@ -406,7 +407,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout
-        if: env.IS_INERT == 'false' && steps.webhook.outputs.configured == 'true'
+        if: env.IS_VALIDATE_ONLY == 'false' && steps.webhook.outputs.configured == 'true'
         uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
@@ -414,7 +415,7 @@ jobs:
           path: send-slack-alert
 
       - name: Send Slack alert
-        if: env.IS_INERT == 'false' && steps.webhook.outputs.configured == 'true'
+        if: env.IS_VALIDATE_ONLY == 'false' && steps.webhook.outputs.configured == 'true'
         uses: ./send-slack-alert/.github/actions/send-slack-alert
         with:
           message: ${{ steps.msg.outputs.message }}

--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -71,7 +71,7 @@ on:
       gh-release-changelog-mode:
         required: false
         type: string
-        default: PR
+        default: HYBRID
       publish-docs:
         required: false
         type: boolean

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -607,9 +607,11 @@ jobs:
           elif [[ "$IS_RELEASE_CANDIDATE" == "true" ]]; then
             DATE=$(date +"%Y-%m-%d")
             CHANGELOG="Prerelease: $NAME ($DATE)"
-          else
+          elif [[ -f CHANGELOG.md ]]; then
             CHANGELOG=$(awk '/^## '"$NAME"'/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md)
             CHANGELOG=$(echo "$CHANGELOG" | sed '/./,$!d' | sed ':a;N;$!ba;s/\n$//')
+          else
+            CHANGELOG="Release: $NAME"
           fi
 
           echo "is-release-candidate=$IS_RELEASE_CANDIDATE" | tee -a "$GITHUB_OUTPUT"

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -99,9 +99,9 @@ on:
         default: ""
       gh-release-changelog-mode:
         required: false
-        description: Mode for changelog builder
+        description: Mode for changelog builder (PR / COMMIT / HYBRID).
         type: string
-        default: PR
+        default: HYBRID
       has-src-dir:
         required: false
         description: Whether the package has a src directory

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -112,6 +112,11 @@ on:
         description: Skip the test wheel step
         type: boolean
         default: false
+      skip-check-manifest:
+        required: false
+        description: Skip check-manifest validation (for repos that intentionally exclude dev tooling from sdist).
+        type: boolean
+        default: false
       wheel-content-ignore:
         required: false
         description: Comma-separated check-wheel-contents codes to ignore.
@@ -284,6 +289,7 @@ jobs:
       packaging: ${{ inputs.packaging }}
       has-src-dir: ${{ inputs.has-src-dir }}
       skip-test-wheel: ${{ inputs.skip-test-wheel }}
+      skip-check-manifest: ${{ inputs.skip-check-manifest }}
       wheel-content-ignore: ${{ inputs.wheel-content-ignore }}
       custom-container: ${{ inputs.custom-container }}
       runner: ${{ inputs.runner }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -694,7 +694,7 @@ jobs:
       && (inputs.publish-docs == true || inputs.validate-only == true)
       && !cancelled()
     with:
-      ref: ${{ inputs.validate-only && inputs.release-ref || format('{0}v{1}', inputs.gh-release-tag-prefix || '', needs.build-test-publish-wheel.outputs.version) }}
+      ref: ${{ (inputs.validate-only || inputs.dry-run) && inputs.release-ref || format('{0}v{1}', inputs.gh-release-tag-prefix || '', needs.build-test-publish-wheel.outputs.version) }}
 
   publish-docs:
     needs: [build-test-publish-wheel, create-gh-release, build-docs]

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ on:
         default: "3.10"
       library-name:
         type: string
-        description: Name of Nemo library
+        description: Human-readable library name (used in PR titles, GH release title, Slack notify)
       dry-run:
         type: boolean
         required: true
@@ -55,6 +55,13 @@ on:
         required: false
         default: false
         description: Skip the version bump commit and PR (for dynamic versioning setups where the version is derived from git tags)
+      bump-targets:
+        type: string
+        required: false
+        default: ""
+        description: |
+          JSON array of bump targets, each `{"python-package": "...", "src-dir": "..."}`.
+          Empty falls back to a single target derived from python-package + has-src-dir.
       packaging:
         required: false
         description: "Packaging tool (supported: setuptools, hatch, uv)"
@@ -164,6 +171,11 @@ on:
         description: Space-separated list of extra packages to pre-install before building with --no-build-isolation (e.g. "grpcio-tools protobuf")
         type: string
         default: ""
+      notify-emails:
+        required: false
+        description: Comma-separated extra email addresses for docs publish notifications.
+        type: string
+        default: ""
     secrets:
       TWINE_USERNAME:
         required: false
@@ -199,295 +211,34 @@ on:
         required: false
 
 permissions:
-  contents: write # To read repository content
-  pull-requests: write # To create PR(s)
+  contents: write
+  pull-requests: write
 
 jobs:
-  check-admin-permission:
-    runs-on: ubuntu-latest
-    if: inputs.restrict-to-admins == true && inputs.validate-only == false
-    steps:
-      - name: Check if user has admin permission
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { data: permissionLevel } = await github.rest.repos.getCollaboratorPermissionLevel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              username: context.actor,
-            });
-
-            const permission = permissionLevel.permission;
-            console.log(`User ${context.actor} has permission: ${permission}`);
-
-            if (permission !== 'admin') {
-              core.setFailed(`User ${context.actor} does not have admin permission (has: ${permission}). Only admins can release.`);
-            }
-
-  bump-next-version:
-    runs-on: ubuntu-latest
-    environment: main
-    needs: [check-admin-permission]
-    if: |
-      !inputs.skip-version-bump
-      && (
-        success() || !failure()
-      )
-      && !cancelled()
-    env:
-      IS_INERT: ${{ inputs.validate-only || inputs.dry-run }}
-      IS_VALIDATE_ONLY: ${{ inputs.validate-only }}
-      PYPROJECT_NAME: ${{ inputs.python-package }}
-      SRC_DIR: ${{ inputs.has-src-dir && 'src/' || '' }}
-      PACKAGING: ${{ inputs.packaging }}
-    steps:
-      - uses: actions/create-github-app-token@v2
-        if: inputs.validate-only == false
-        id: app-token
-        with:
-          app-id: ${{ inputs.app-id }}
-          private-key: ${{ secrets.BOT_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          path: ${{ github.run_id }}
-          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-          fetch-tags: true
-          ref: ${{ inputs.release-ref }}
-
-      - name: Install GPG
-        if: inputs.validate-only == false
-        run: sudo apt-get install -y gnupg2
-
-      - name: Import GPG key (for signing)
-        if: inputs.validate-only == false
-        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
-        id: gpg-action
-        with:
-          gpg_private_key: ${{ secrets.SSH_KEY }}
-          passphrase: ${{ secrets.SSH_PWD }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          workdir: ${{ github.run_id }}
-
-      - name: Bump version
-        id: bump-version
-        run: |
-          cd ${{ github.run_id }}
-          cd ${{ inputs.root-dir }}
-
-          PACKAGE_INFO_FILE="$SRC_DIR${PYPROJECT_NAME//.//}/package_info.py"
-
-          if [[ "$PACKAGING" == "setuptools" || "$PACKAGING" == "uv" ]]; then
-            MAJOR=$(cat $PACKAGE_INFO_FILE | awk '/^MAJOR = /' | awk -F"= " '{print $2}')
-            MINOR=$(cat $PACKAGE_INFO_FILE | awk '/^MINOR = /' | awk -F"= " '{print $2}')
-            PATCH=$(cat $PACKAGE_INFO_FILE | awk '/^PATCH = /' | awk -F"= " '{print $2}')
-            PRERELEASE=$(cat $PACKAGE_INFO_FILE | awk '/^PRE_RELEASE = /' | awk -F"= " '{print $2}' | tr -d '"' | tr -d "'")
-
-            if [[ "$PRERELEASE" != "" ]]; then
-              if [[ "$PRERELEASE" == *rc* ]]; then
-                NEXT_PATCH=$PATCH
-                NEXT_PRERELEASE=rc$((${PRERELEASE#rc} + 1))
-              elif [[ "$PRERELEASE" == *a* ]]; then
-                NEXT_PATCH=$PATCH
-                NEXT_PRERELEASE=a$((${PRERELEASE#a} + 1))
-              else
-                echo "Unknown pre-release: $PRERELEASE"
-                exit 1
-              fi
-            else
-              NEXT_PATCH=$((${PATCH} + 1))
-              NEXT_PRERELEASE=$PRERELEASE
-            fi
-
-            sed -i "/^PATCH/c\PATCH = $NEXT_PATCH" $PACKAGE_INFO_FILE
-            sed -i "/^PRE_RELEASE/c\PRE_RELEASE = \"$NEXT_PRERELEASE\"" $PACKAGE_INFO_FILE
-
-            echo "version=$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE" | tee -a "$GITHUB_OUTPUT"
-          elif [[ "$PACKAGING" == "hatch" ]]; then
-            pip install hatch
-            VERSION=$(hatch version)
-            MAJOR=$(echo "$VERSION" | cut -d. -f1)
-            MINOR=$(echo "$VERSION" | cut -d. -f2)
-            PATCH_FULL=$(echo "$VERSION" | cut -d. -f3-)
-            PATCH=$(echo "$PATCH_FULL" | grep -oP '^\d+')
-            PRERELEASE=$(echo "$PATCH_FULL" | grep -oP '(?<=\d)(rc\d+|a\d+)' || true)
-
-            if [[ "$PRERELEASE" != "" ]]; then
-              if [[ "$PRERELEASE" == rc* ]]; then
-                NEXT_PATCH=$PATCH
-                NEXT_PRERELEASE=rc$((${PRERELEASE#rc} + 1))
-              elif [[ "$PRERELEASE" == a* ]]; then
-                NEXT_PATCH=$PATCH
-                NEXT_PRERELEASE=a$((${PRERELEASE#a} + 1))
-              else
-                echo "Unknown pre-release: $PRERELEASE"
-                exit 1
-              fi
-            else
-              NEXT_PATCH=$((PATCH + 1))
-              NEXT_PRERELEASE=$PRERELEASE
-            fi
-
-            hatch version "$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE"
-            echo "version=$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE" | tee -a "$GITHUB_OUTPUT"
-          fi
-
-      - name: Record computed version (validate-only)
-        if: inputs.validate-only == true
-        run: |
-          echo "Computed next version: v${{ steps.bump-version.outputs.version }}" | tee -a "$GITHUB_STEP_SUMMARY"
-          echo "validate-only=true → skipping branch push, PR creation, status-check wait, merge, and branch delete." | tee -a "$GITHUB_STEP_SUMMARY"
-
-      - name: Create and push deployment branch
-        if: inputs.validate-only == false
-        env:
-          PYPROJECT_NAME: ${{ inputs.python-package }}
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          cd ${{ github.run_id }}
-          cd ${{ inputs.root-dir }}
-
-          PACKAGE_INFO_FILE="$SRC_DIR${PYPROJECT_NAME//.//}/package_info.py"
-
-          TMP_BRANCH="deploy-release/$(uuidgen)"
-          git checkout -b "$TMP_BRANCH"
-          git add $PACKAGE_INFO_FILE
-          git commit -sS -m "beep boop 🤖: Bumping ${PYPROJECT_NAME} to v${{ steps.bump-version.outputs.version }}" || echo "No changes to commit"
-          git push -u origin "$TMP_BRANCH"
-          echo "TMP_BRANCH=$TMP_BRANCH" | tee -a $GITHUB_ENV
-
-          # Create PR to collect app based status checks that run on PRs only
-          # (like DCO check)
-          gh pr create \
-            --base ${{ inputs.version-bump-branch }} \
-            --head $TMP_BRANCH \
-            --title "beep boop 🤖: Bumping ${PYPROJECT_NAME} to v${{ steps.bump-version.outputs.version }}" \
-            --body "This is an automated PR to bump ${{ inputs.library-name }}:${PYPROJECT_NAME} to v${{ steps.bump-version.outputs.version }}."
-
-      - name: Wait for status checks on tmp branch
-        if: inputs.validate-only == false
-        uses: actions/github-script@v8
-        id: wait-status
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            const branch = process.env.TMP_BRANCH;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-
-            // Get latest commit SHA of branch
-            const { data: refData } = await github.rest.git.getRef({
-              owner,
-              repo,
-              ref: `heads/${branch}`,  // note: no 'refs/' prefix here
-            });
-
-            const sha = refData.object.sha;
-
-            console.log(`Polling status for commit SHA: ${sha}`);
-
-            let checksPassed = false;
-            let maxAttempts = 3000;
-            let attempt = 0;
-            const delay = ms => new Promise(res => setTimeout(res, ms));
-
-            while (!checksPassed && attempt < maxAttempts) {
-              attempt++;
-
-              // Use commit SHA instead of branch ref
-              const { data: status } = await github.rest.repos.getCombinedStatusForRef({
-                owner,
-                repo,
-                ref: sha,
-              });
-
-              const { data: checks } = await github.rest.checks.listForRef({
-                owner,
-                repo,
-                ref: sha,
-              });
-
-              const allStatuses = status.statuses;
-              const allChecks = checks.check_runs;
-
-              if (allStatuses.length === 0 && allChecks.length === 0) {
-                console.log(`Attempt ${attempt}: No checks or statuses yet. Waiting...`);
-                await delay(10000);
-                continue;
-              }
-
-              const statusesOk = allStatuses.every(s => s.state === 'success');
-              const checksOk = allChecks.every(c => c.status === 'completed');
-
-              if (statusesOk && checksOk) {
-                console.log('✅ All checks passed.');
-                checksPassed = true;
-                break
-              }
-
-              console.log(`Attempt ${attempt}: Checks not complete yet. Waiting...`);
-              await delay(10000);
-            }
-
-            if (!checksPassed) {
-              core.setFailed('❌ Status checks did not pass in time');
-            }
-
-      - name: Merge into ${{ inputs.version-bump-branch }}
-        if: inputs.validate-only == false
-        run: |
-          cd ${{ github.run_id }}
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          CMD=$(echo -E 'git push origin ${{ inputs.version-bump-branch }}')
-
-          if [[ "$IS_INERT" == "true" ]]; then
-            echo "dry-run enabled, would have run: $CMD"
-          else
-            # Here we account for potential race conditions from multiple concurrent releases.
-            # Those can be legit (operating on different packages within the monorepo, for example)
-            # but the pushes would be still rejected purely because of git's inability to
-            # push non-fast-forward updates to the branch. In this case we would need to let
-            # a retry.
-            git fetch origin ${{ inputs.version-bump-branch }}
-            git checkout ${{ inputs.version-bump-branch }}
-            git merge ${{ env.TMP_BRANCH }}
-
-            for attempt in {1..3}; do
-              if eval "$CMD"; then
-                echo "Git push succeeded on attempt $attempt"
-                break
-              else
-                echo "Git push failed on attempt $attempt"
-                if [[ $attempt -lt 3 ]]; then
-                  sleep $((RANDOM % 3 + 1))
-                  # We refetch, reset and re-merge. Note resetting because the local
-                  # branch is "contaminated" with previous merge attempt.
-                  git fetch origin ${{ inputs.version-bump-branch }}
-                  git reset --hard origin/${{ inputs.version-bump-branch }}
-                  git merge ${{ env.TMP_BRANCH }}
-                else
-                  echo "Git push failed after 3 attempts"
-                  exit 1
-                fi
-              fi
-            done
-          fi
-
-      - name: Delete ${{ env.TMP_BRANCH }} branch
-        if: always() && inputs.validate-only == false && env.TMP_BRANCH != ''
-        run: |
-          cd ${{ github.run_id }}
-          git push -d origin ${{ env.TMP_BRANCH }}
+  bump:
+    uses: ./.github/workflows/_release_bump.yml
+    with:
+      release-ref: ${{ inputs.release-ref }}
+      validate-only: ${{ inputs.validate-only }}
+      dry-run: ${{ inputs.dry-run }}
+      version-bump-branch: ${{ inputs.version-bump-branch }}
+      skip-version-bump: ${{ inputs.skip-version-bump }}
+      restrict-to-admins: ${{ inputs.restrict-to-admins }}
+      app-id: ${{ inputs.app-id }}
+      library-name: ${{ inputs.library-name }}
+      bump-targets: ${{ inputs.bump-targets }}
+      python-package: ${{ inputs.python-package }}
+      has-src-dir: ${{ inputs.has-src-dir }}
+      packaging: ${{ inputs.packaging }}
+      root-dir: ${{ inputs.root-dir }}
+    secrets:
+      BOT_KEY: ${{ secrets.BOT_KEY }}
+      SSH_KEY: ${{ secrets.SSH_KEY }}
+      SSH_PWD: ${{ secrets.SSH_PWD }}
 
   build-test-publish-wheel:
+    needs: bump
     uses: ./.github/workflows/_build_test_publish_wheel.yml
-    needs: bump-next-version
     if: |
       (
         success() || !failure()
@@ -515,235 +266,42 @@ jobs:
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  create-gh-release:
-    needs: [build-test-publish-wheel]
-    runs-on: ubuntu-latest
-    environment: ${{ (inputs.validate-only || inputs.dry-run) && 'public' || 'main' }}
+  finalize:
+    needs: [bump, build-test-publish-wheel]
+    uses: ./.github/workflows/_release_finalize.yml
     if: |
       (
         success() || !failure()
       )
-      && inputs.create-gh-release == true
-      && !cancelled()
-    outputs:
-      is-release-candidate: ${{ steps.version-number.outputs.is-release-candidate }}
-    env:
-      REPOSITORY: ${{ github.repository }}
-      PROJECT_NAME: ${{ inputs.library-name }}
-      VERSION: ${{ needs.build-test-publish-wheel.outputs.version }}
-      TAG_PREFIX: ${{ inputs.gh-release-tag-prefix || '' }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          path: ${{ github.run_id }}
-          ref: ${{ inputs.release-ref }}
-          token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Determine fromTag for changelog
-        id: determine-from-tag
-        if: inputs.gh-release-use-changelog-builder == true
-        run: |
-          cd ${{ github.run_id }}
-
-          # If gh-release-from-tag is provided, use it
-          if [[ -n "${{ inputs.gh-release-from-tag }}" ]]; then
-            FROM_TAG="${{ inputs.gh-release-from-tag }}"
-            echo "Using provided fromTag: $FROM_TAG"
-          else
-            # Get the most recent tag (optionally scoped by TAG_PREFIX for monorepos)
-            if [[ -n "$TAG_PREFIX" ]]; then
-              FROM_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname 2>/dev/null | head -n1 || echo "")
-            else
-              FROM_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-            fi
-            if [[ -z "$FROM_TAG" ]]; then
-              echo "No previous tags found, leaving fromTag empty"
-            else
-              echo "Auto-detected most recent tag: $FROM_TAG"
-            fi
-          fi
-
-          echo "from-tag=$FROM_TAG" >> $GITHUB_OUTPUT
-
-      - name: Build Changelog
-        id: build-changelog
-        if: inputs.gh-release-use-changelog-builder == true
-        uses: mikepenz/release-changelog-builder-action@v6.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-        with:
-          configuration: ${{ github.run_id }}/${{ inputs.gh-release-changelog-config }}
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          ignorePreReleases: "false"
-          failOnError: "false"
-          fromTag: ${{ steps.determine-from-tag.outputs.from-tag }}
-          toTag: ${{ inputs.release-ref }}
-          mode: ${{ inputs.gh-release-changelog-mode }}
-          includeOnlyPaths: ${{ inputs.gh-release-changelog-included-paths }}
-
-      - name: Create release
-        id: version-number
-        env:
-          SHA: ${{ inputs.release-ref }}
-          GH_TOKEN: ${{ secrets.PAT || '' }}
-          IS_INERT: ${{ inputs.validate-only || inputs.dry-run }}
-          BUILT_CHANGELOG: ${{ steps.build-changelog.outputs.changelog }}
-        run: |
-          cd ${{ github.run_id }}
-          cd ${{ inputs.root-dir }}
-
-          IS_RELEASE_CANDIDATE=$([[ "$VERSION" == *rc* ]] && echo "true" || echo "false")
-          IS_ALPHA=$([[ "$VERSION" == *a* ]] && echo "true" || echo "false")
-          IS_PRERELEASE=$([[ "$IS_RELEASE_CANDIDATE" == "true" || "$IS_ALPHA" == "true" ]] && echo "true" || echo "false")
-          NAME="NVIDIA $PROJECT_NAME ${VERSION}"
-
-          # Use built changelog if available, otherwise fall back to CHANGELOG.md
-          if [[ -n "$BUILT_CHANGELOG" ]]; then
-            CHANGELOG="$BUILT_CHANGELOG"
-          elif [[ "$IS_RELEASE_CANDIDATE" == "true" ]]; then
-            DATE=$(date +"%Y-%m-%d")
-            CHANGELOG="Prerelease: $NAME ($DATE)"
-          elif [[ -f CHANGELOG.md ]]; then
-            CHANGELOG=$(awk '/^## '"$NAME"'/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md)
-            CHANGELOG=$(echo "$CHANGELOG" | sed '/./,$!d' | sed ':a;N;$!ba;s/\n$//')
-          else
-            CHANGELOG="Release: $NAME"
-          fi
-
-          echo "is-release-candidate=$IS_RELEASE_CANDIDATE" | tee -a "$GITHUB_OUTPUT"
-
-          PAYLOAD=$(jq -nc \
-                      --arg TAG_NAME "${TAG_PREFIX}v${VERSION}" \
-                      --arg CI_COMMIT_BRANCH "$SHA" \
-                      --arg NAME "$NAME" \
-                      --arg BODY "$CHANGELOG" \
-                      --argjson PRERELEASE "$IS_PRERELEASE" \
-                      '{
-                        "tag_name": $TAG_NAME,
-                        "target_commitish": $CI_COMMIT_BRANCH,
-                        "name": $NAME,
-                        "body": $BODY,
-                        "draft": false,
-                        "prerelease": $PRERELEASE,
-                      }'
-                  )
-          echo -E "$PAYLOAD" > payload.txt
-
-          CMD=$(echo -E 'curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer '"$GH_TOKEN"'" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/'"$REPOSITORY"'/releases \
-            -d @payload.txt
-          ')
-
-          if [[ "$IS_INERT" == "true" ]]; then
-            echo -E "$CMD"
-          else
-            eval "$CMD"
-          fi
-
-  notify:
-    needs: [build-test-publish-wheel, create-gh-release]
-    runs-on: ubuntu-latest
-    if: |
-      (
-        success() || !failure()
-      )
-      && inputs.validate-only == false
-      && !cancelled()
-    environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
-    env:
-      GH_URL: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.gh-release-tag-prefix || '' }}v${{ needs.build-test-publish-wheel.outputs.version }}
-      PYPI_URL: https://${{ inputs.dry-run == true && 'test.' || '' }}pypi.org/project/${{ needs.build-test-publish-wheel.outputs.pypi-name }}/${{ needs.build-test-publish-wheel.outputs.version }}/
-      PROJECT_NAME: ${{ inputs.library-name }}
-      VERSION: ${{ needs.build-test-publish-wheel.outputs.version }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.17.0
-          path: send-slack-alert
-
-      - name: Send Slack alert
-        uses: ./send-slack-alert/.github/actions/send-slack-alert
-        env:
-          MESSAGE: |
-            ${{ inputs.dry-run == true && 'This is a dry-run, nothing actually happened: ' || '' }}We have released `${{ env.VERSION }}` of `NVIDIA ${{ env.PROJECT_NAME }}` 🚀✨🎉
-
-            • <${{ env.GH_URL }}|GitHub release>
-            • <${{ env.PYPI_URL }}|PyPi release>
-
-        with:
-          message: ${{ env.MESSAGE }}
-          webhook: ${{ secrets.SLACK_WEBHOOK }}
-
-  build-docs:
-    needs: [build-test-publish-wheel, create-gh-release]
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.72.0
-    if: |
-      (
-        success() || !failure()
-      )
-      && (inputs.publish-docs == true || inputs.validate-only == true)
       && !cancelled()
     with:
-      ref: ${{ (inputs.validate-only || inputs.dry-run) && inputs.release-ref || format('{0}v{1}', inputs.gh-release-tag-prefix || '', needs.build-test-publish-wheel.outputs.version) }}
-
-  publish-docs:
-    needs: [build-test-publish-wheel, create-gh-release, build-docs]
-    runs-on: ubuntu-latest
-    environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
-    if: |
-      (
-        success() || !failure()
-      )
-      && inputs.publish-docs == true
-      && inputs.validate-only == false
-      && !cancelled()
-    env:
-      VERSION: ${{ needs.build-test-publish-wheel.outputs.version }}
-      LIBRARY_NAME: ${{ inputs.library-name }}
-      S3_TARGET_PATH: ${{ inputs.docs-target-path }}
-    steps:
-      - name: Checkout FW-CI-templates
-        uses: actions/checkout@v6
-        with:
-          repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.72.0
-          path: FW-CI-templates
-
-      - name: Generate request name
-        id: request-name
-        shell: bash
-        run: |
-          REQUEST_NAME="${S3_TARGET_PATH//\//-}-publish-docs-${{ github.run_id }}"
-          echo "value=${REQUEST_NAME}" >> $GITHUB_OUTPUT
-
-      - name: Publish documentation
-        uses: ./FW-CI-templates/.github/actions/publish-docs
-        with:
-          dry-run: ${{ inputs.dry-run }}
-          artifacts-name: docs-html
-          artifacts-path: _build/html
-          emails-csv: ${{ inputs.notify-emails && format('{0},{1}', vars.docs_release_emails, inputs.notify-emails) || vars.docs_release_emails }}
-          overwrite-latest-on-tag: true
-          docs-version-override: ${{ env.VERSION }}
-          project-type: ${{ inputs.docs-project-type }}
-          request-name: ${{ steps.request-name.outputs.value }}
-          aws-region: ${{ vars.DOCS_AWS_REGION }}
-          aws-role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          akamai-host: ${{ secrets.AKAMAI_HOST }}
-          akamai-client-token: ${{ secrets.AKAMAI_CLIENT_TOKEN }}
-          akamai-client-secret: ${{ secrets.AKAMAI_CLIENT_SECRET }}
-          akamai-access-token: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
-          s3-target-root: ${{ secrets.S3_BUCKET_NAME }}
-          s3-target-path: ${{ inputs.docs-target-path }}
+      release-ref: ${{ inputs.release-ref }}
+      release-version: ${{ needs.bump.outputs.release-version || needs.build-test-publish-wheel.outputs.version }}
+      library-name: ${{ inputs.library-name }}
+      pypi-name: ${{ needs.build-test-publish-wheel.outputs.pypi-name }}
+      validate-only: ${{ inputs.validate-only }}
+      dry-run: ${{ inputs.dry-run }}
+      create-gh-release: ${{ inputs.create-gh-release }}
+      gh-release-tag-prefix: ${{ inputs.gh-release-tag-prefix }}
+      gh-release-use-changelog-builder: ${{ inputs.gh-release-use-changelog-builder }}
+      gh-release-changelog-config: ${{ inputs.gh-release-changelog-config }}
+      gh-release-changelog-included-paths: ${{ inputs.gh-release-changelog-included-paths }}
+      gh-release-from-tag: ${{ inputs.gh-release-from-tag }}
+      gh-release-changelog-mode: ${{ inputs.gh-release-changelog-mode }}
+      publish-docs: ${{ inputs.publish-docs }}
+      docs-target-path: ${{ inputs.docs-target-path }}
+      docs-project-type: ${{ inputs.docs-project-type }}
+      notify-emails: ${{ inputs.notify-emails }}
+      root-dir: ${{ inputs.root-dir }}
+    secrets:
+      PAT: ${{ secrets.PAT }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
+      AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AKAMAI_HOST: ${{ secrets.AKAMAI_HOST }}
+      AKAMAI_CLIENT_TOKEN: ${{ secrets.AKAMAI_CLIENT_TOKEN }}
+      AKAMAI_CLIENT_SECRET: ${{ secrets.AKAMAI_CLIENT_SECRET }}
+      AKAMAI_ACCESS_TOKEN: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
+      S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -169,6 +169,21 @@ on:
         description: Type of documentation project
         type: string
         default: single-docset
+      publish-as-latest:
+        required: false
+        description: Overwrite the "latest" docs alias when publishing on a version tag.
+        type: boolean
+        default: true
+      update-version-picker:
+        required: false
+        description: Refresh the in-page docs version-picker after publishing.
+        type: boolean
+        default: true
+      run-on-version-tag-only:
+        required: false
+        description: Skip the publish step unless the workflow is running on a version tag.
+        type: boolean
+        default: false
       container-options:
         required: false
         description: Options to pass to the container
@@ -298,6 +313,9 @@ jobs:
       publish-docs: ${{ inputs.publish-docs }}
       docs-target-path: ${{ inputs.docs-target-path }}
       docs-project-type: ${{ inputs.docs-project-type }}
+      publish-as-latest: ${{ inputs.publish-as-latest }}
+      update-version-picker: ${{ inputs.update-version-picker }}
+      run-on-version-tag-only: ${{ inputs.run-on-version-tag-only }}
       notify-emails: ${{ inputs.notify-emails }}
       root-dir: ${{ inputs.root-dir }}
       app-id: ${{ inputs.app-id }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -40,6 +40,11 @@ on:
         type: boolean
         required: true
         description: Do not publish a wheel and GitHub release.
+      validate-only:
+        type: boolean
+        required: false
+        default: false
+        description: Run all release steps in compute-only mode — no pushes, no PRs, no PyPI, no GH release, no docs publish. Used by per-PR rehearsals.
       version-bump-branch:
         type: string
         required: false
@@ -161,37 +166,37 @@ on:
         default: ""
     secrets:
       TWINE_USERNAME:
-        required: true
+        required: false
       TWINE_PASSWORD:
-        required: true
+        required: false
       SLACK_WEBHOOK_ADMIN:
-        required: true
+        required: false
       SLACK_WEBHOOK:
-        required: true
+        required: false
       PAT:
-        required: true
+        required: false
       SSH_KEY:
         required: false
       SSH_PWD:
         required: false
       BOT_KEY:
-        required: true
+        required: false
       AWS_ASSUME_ROLE_ARN:
-        required: true
+        required: false
       AWS_ACCESS_KEY_ID:
-        required: true
+        required: false
       AWS_SECRET_ACCESS_KEY:
-        required: true
+        required: false
       AKAMAI_HOST:
-        required: true
+        required: false
       AKAMAI_CLIENT_TOKEN:
-        required: true
+        required: false
       AKAMAI_CLIENT_SECRET:
-        required: true
+        required: false
       AKAMAI_ACCESS_TOKEN:
-        required: true
+        required: false
       S3_BUCKET_NAME:
-        required: true
+        required: false
 
 permissions:
   contents: write # To read repository content
@@ -200,7 +205,7 @@ permissions:
 jobs:
   check-admin-permission:
     runs-on: ubuntu-latest
-    if: inputs.restrict-to-admins == true
+    if: inputs.restrict-to-admins == true && inputs.validate-only == false
     steps:
       - name: Check if user has admin permission
         uses: actions/github-script@v7
@@ -219,41 +224,10 @@ jobs:
               core.setFailed(`User ${context.actor} does not have admin permission (has: ${permission}). Only admins can release.`);
             }
 
-  build-test-publish-wheel-dry-run:
-    name: Build test publish wheel (dry run)
-    needs: check-admin-permission
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.88.1
-    if: |
-      (
-        success() || !failure()
-      )
-      && !cancelled()
-      && inputs.dry-run == false
-    with:
-      dry-run: true
-      python-package: ${{ inputs.python-package }}
-      python-version: ${{ inputs.python-version }}
-      ref: ${{ inputs.release-ref }}
-      packaging: ${{ inputs.packaging }}
-      has-src-dir: ${{ inputs.has-src-dir }}
-      skip-test-wheel: ${{ inputs.skip-test-wheel }}
-      custom-container: ${{ inputs.custom-container }}
-      runner: ${{ inputs.runner }}
-      no-build-isolation: ${{ inputs.no-build-isolation }}
-      root-dir: ${{ inputs.root-dir }}
-      submodules: ${{ inputs.submodules }}
-      container-options: ${{ inputs.container-options }}
-      extra-no-build-isolation-packages: ${{ inputs.extra-no-build-isolation-packages }}
-    secrets:
-      TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-      TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
   bump-next-version:
     runs-on: ubuntu-latest
-    environment: main # ${{ inputs.dry-run == true && 'public' || 'main' }}
-    needs: [check-admin-permission, build-test-publish-wheel-dry-run]
+    environment: main
+    needs: [check-admin-permission]
     if: |
       !inputs.skip-version-bump
       && (
@@ -261,12 +235,14 @@ jobs:
       )
       && !cancelled()
     env:
-      IS_DRY_RUN: ${{ inputs.dry-run }}
+      IS_INERT: ${{ inputs.validate-only || inputs.dry-run }}
+      IS_VALIDATE_ONLY: ${{ inputs.validate-only }}
       PYPROJECT_NAME: ${{ inputs.python-package }}
       SRC_DIR: ${{ inputs.has-src-dir && 'src/' || '' }}
       PACKAGING: ${{ inputs.packaging }}
     steps:
       - uses: actions/create-github-app-token@v2
+        if: inputs.validate-only == false
         id: app-token
         with:
           app-id: ${{ inputs.app-id }}
@@ -276,15 +252,17 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           fetch-tags: true
           ref: ${{ inputs.release-ref }}
 
       - name: Install GPG
+        if: inputs.validate-only == false
         run: sudo apt-get install -y gnupg2
 
       - name: Import GPG key (for signing)
+        if: inputs.validate-only == false
         uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec
         id: gpg-action
         with:
@@ -357,7 +335,14 @@ jobs:
             echo "version=$MAJOR.$MINOR.$NEXT_PATCH$NEXT_PRERELEASE" | tee -a "$GITHUB_OUTPUT"
           fi
 
+      - name: Record computed version (validate-only)
+        if: inputs.validate-only == true
+        run: |
+          echo "Computed next version: v${{ steps.bump-version.outputs.version }}" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "validate-only=true → skipping branch push, PR creation, status-check wait, merge, and branch delete." | tee -a "$GITHUB_STEP_SUMMARY"
+
       - name: Create and push deployment branch
+        if: inputs.validate-only == false
         env:
           PYPROJECT_NAME: ${{ inputs.python-package }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -383,6 +368,7 @@ jobs:
             --body "This is an automated PR to bump ${{ inputs.library-name }}:${PYPROJECT_NAME} to v${{ steps.bump-version.outputs.version }}."
 
       - name: Wait for status checks on tmp branch
+        if: inputs.validate-only == false
         uses: actions/github-script@v8
         id: wait-status
         with:
@@ -451,6 +437,7 @@ jobs:
             }
 
       - name: Merge into ${{ inputs.version-bump-branch }}
+        if: inputs.validate-only == false
         run: |
           cd ${{ github.run_id }}
 
@@ -459,7 +446,7 @@ jobs:
 
           CMD=$(echo -E 'git push origin ${{ inputs.version-bump-branch }}')
 
-          if [[ "$IS_DRY_RUN" == "true" ]]; then
+          if [[ "$IS_INERT" == "true" ]]; then
             echo "dry-run enabled, would have run: $CMD"
           else
             # Here we account for potential race conditions from multiple concurrent releases.
@@ -493,13 +480,13 @@ jobs:
           fi
 
       - name: Delete ${{ env.TMP_BRANCH }} branch
-        if: always()
+        if: always() && inputs.validate-only == false && env.TMP_BRANCH != ''
         run: |
           cd ${{ github.run_id }}
           git push -d origin ${{ env.TMP_BRANCH }}
 
   build-test-publish-wheel:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.88.1
+    uses: ./.github/workflows/_build_test_publish_wheel.yml
     needs: bump-next-version
     if: |
       (
@@ -507,7 +494,7 @@ jobs:
       )
       && !cancelled()
     with:
-      dry-run: ${{ inputs.dry-run }}
+      no-publish: ${{ inputs.validate-only || inputs.dry-run }}
       python-package: ${{ inputs.python-package }}
       python-version: ${{ inputs.python-version }}
       ref: ${{ inputs.release-ref }}
@@ -519,7 +506,7 @@ jobs:
       no-build-isolation: ${{ inputs.no-build-isolation }}
       root-dir: ${{ inputs.root-dir }}
       submodules: ${{ inputs.submodules }}
-      container-options: ${{ inputs.container-options }}      
+      container-options: ${{ inputs.container-options }}
       extra-no-build-isolation-packages: ${{ inputs.extra-no-build-isolation-packages }}
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
@@ -530,7 +517,7 @@ jobs:
   create-gh-release:
     needs: [build-test-publish-wheel]
     runs-on: ubuntu-latest
-    environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
+    environment: ${{ (inputs.validate-only || inputs.dry-run) && 'public' || 'main' }}
     if: |
       (
         success() || !failure()
@@ -601,8 +588,8 @@ jobs:
         id: version-number
         env:
           SHA: ${{ inputs.release-ref }}
-          GH_TOKEN: ${{ secrets.PAT }}
-          IS_DRY_RUN: ${{ inputs.dry-run }}
+          GH_TOKEN: ${{ secrets.PAT || '' }}
+          IS_INERT: ${{ inputs.validate-only || inputs.dry-run }}
           BUILT_CHANGELOG: ${{ steps.build-changelog.outputs.changelog }}
         run: |
           cd ${{ github.run_id }}
@@ -652,7 +639,7 @@ jobs:
             -d @payload.txt
           ')
 
-          if [[ "$IS_DRY_RUN" == "true" ]]; then
+          if [[ "$IS_INERT" == "true" ]]; then
             echo -E "$CMD"
           else
             eval "$CMD"
@@ -661,6 +648,12 @@ jobs:
   notify:
     needs: [build-test-publish-wheel, create-gh-release]
     runs-on: ubuntu-latest
+    if: |
+      (
+        success() || !failure()
+      )
+      && inputs.validate-only == false
+      && !cancelled()
     environment: ${{ inputs.dry-run == true && 'public' || 'main' }}
     env:
       GH_URL: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.gh-release-tag-prefix || '' }}v${{ needs.build-test-publish-wheel.outputs.version }}
@@ -709,6 +702,7 @@ jobs:
         success() || !failure()
       )
       && inputs.publish-docs == true
+      && inputs.validate-only == false
       && !cancelled()
     env:
       VERSION: ${{ needs.build-test-publish-wheel.outputs.version }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -241,8 +241,6 @@ on:
         required: false
       SLACK_WEBHOOK_ADMIN:
         required: false
-      SLACK_WEBHOOK:
-        required: false
       BOT_KEY:
         required: false
       AWS_ASSUME_ROLE_ARN:
@@ -317,7 +315,6 @@ jobs:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
   finalize:
     needs: [bump, build-test-publish-wheel]
@@ -357,7 +354,6 @@ jobs:
       app-id: ${{ inputs.app-id }}
     secrets:
       BOT_KEY: ${{ secrets.BOT_KEY }}
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
       AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -112,6 +112,11 @@ on:
         description: Skip the test wheel step
         type: boolean
         default: false
+      wheel-content-ignore:
+        required: false
+        description: Comma-separated check-wheel-contents codes to ignore.
+        type: string
+        default: "W002,W004"
       skip-wheel-build:
         required: false
         description: |
@@ -254,6 +259,7 @@ jobs:
       packaging: ${{ inputs.packaging }}
       has-src-dir: ${{ inputs.has-src-dir }}
       skip-test-wheel: ${{ inputs.skip-test-wheel }}
+      wheel-content-ignore: ${{ inputs.wheel-content-ignore }}
       custom-container: ${{ inputs.custom-container }}
       runner: ${{ inputs.runner }}
       no-build-isolation: ${{ inputs.no-build-isolation }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -209,6 +209,11 @@ on:
         description: Fail the docs build on Sphinx warnings.
         type: boolean
         default: true
+      docs-skip-linkcheck:
+        required: false
+        description: Skip Sphinx linkcheck.
+        type: boolean
+        default: false
       container-options:
         required: false
         description: Options to pass to the container
@@ -346,6 +351,7 @@ jobs:
       docs-requirements-file: ${{ inputs.docs-requirements-file }}
       docs-directory: ${{ inputs.docs-directory }}
       docs-fail-on-warning: ${{ inputs.docs-fail-on-warning }}
+      docs-skip-linkcheck: ${{ inputs.docs-skip-linkcheck }}
       notify-emails: ${{ inputs.notify-emails }}
       root-dir: ${{ inputs.root-dir }}
       app-id: ${{ inputs.app-id }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -193,10 +193,6 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
-      SSH_KEY:
-        required: false
-      SSH_PWD:
-        required: false
       BOT_KEY:
         required: false
       AWS_ASSUME_ROLE_ARN:
@@ -239,8 +235,6 @@ jobs:
       root-dir: ${{ inputs.root-dir }}
     secrets:
       BOT_KEY: ${{ secrets.BOT_KEY }}
-      SSH_KEY: ${{ secrets.SSH_KEY }}
-      SSH_PWD: ${{ secrets.SSH_PWD }}
 
   build-test-publish-wheel:
     needs: bump

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -281,8 +281,7 @@ jobs:
       has-src-dir: ${{ inputs.has-src-dir }}
       packaging: ${{ inputs.packaging }}
       root-dir: ${{ inputs.root-dir }}
-    secrets:
-      BOT_KEY: ${{ secrets.BOT_KEY }}
+    secrets: inherit
 
   build-test-publish-wheel:
     needs: bump
@@ -311,10 +310,7 @@ jobs:
       submodules: ${{ inputs.submodules }}
       container-options: ${{ inputs.container-options }}
       extra-no-build-isolation-packages: ${{ inputs.extra-no-build-isolation-packages }}
-    secrets:
-      TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-      TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
+    secrets: inherit
 
   finalize:
     needs: [bump, build-test-publish-wheel]
@@ -352,14 +348,4 @@ jobs:
       notify-emails: ${{ inputs.notify-emails }}
       root-dir: ${{ inputs.root-dir }}
       app-id: ${{ inputs.app-id }}
-    secrets:
-      BOT_KEY: ${{ secrets.BOT_KEY }}
-      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
-      AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AKAMAI_HOST: ${{ secrets.AKAMAI_HOST }}
-      AKAMAI_CLIENT_TOKEN: ${{ secrets.AKAMAI_CLIENT_TOKEN }}
-      AKAMAI_CLIENT_SECRET: ${{ secrets.AKAMAI_CLIENT_SECRET }}
-      AKAMAI_ACCESS_TOKEN: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
-      S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+    secrets: inherit

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -199,6 +199,16 @@ on:
         description: pip-installable requirements.txt for docs install (instead of uv sync --only-group docs).
         type: string
         default: ""
+      docs-directory:
+        required: false
+        description: Sphinx docs directory (where conf.py lives). Defaults to `docs`.
+        type: string
+        default: "docs"
+      docs-fail-on-warning:
+        required: false
+        description: Fail the docs build on Sphinx warnings.
+        type: boolean
+        default: true
       container-options:
         required: false
         description: Options to pass to the container
@@ -334,6 +344,8 @@ jobs:
       run-on-version-tag-only: ${{ inputs.run-on-version-tag-only }}
       docs-root-dir: ${{ inputs.docs-root-dir }}
       docs-requirements-file: ${{ inputs.docs-requirements-file }}
+      docs-directory: ${{ inputs.docs-directory }}
+      docs-fail-on-warning: ${{ inputs.docs-fail-on-warning }}
       notify-emails: ${{ inputs.notify-emails }}
       root-dir: ${{ inputs.root-dir }}
       app-id: ${{ inputs.app-id }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -64,7 +64,7 @@ on:
           Empty falls back to a single target derived from python-package + has-src-dir.
       packaging:
         required: false
-        description: "Packaging tool (supported: setuptools, hatch, uv)"
+        description: "Packaging tool (supported: setuptools, uv)"
         type: string
         default: setuptools
       create-gh-release:

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -193,8 +193,6 @@ on:
         required: false
       SLACK_WEBHOOK:
         required: false
-      PAT:
-        required: false
       SSH_KEY:
         required: false
       SSH_PWD:
@@ -302,8 +300,9 @@ jobs:
       docs-project-type: ${{ inputs.docs-project-type }}
       notify-emails: ${{ inputs.notify-emails }}
       root-dir: ${{ inputs.root-dir }}
+      app-id: ${{ inputs.app-id }}
     secrets:
-      PAT: ${{ secrets.PAT }}
+      BOT_KEY: ${{ secrets.BOT_KEY }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
       AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_ASSUME_ROLE_ARN }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -238,6 +238,7 @@ jobs:
       BOT_KEY: ${{ secrets.BOT_KEY }}
       SSH_KEY: ${{ secrets.SSH_KEY }}
       SSH_PWD: ${{ secrets.SSH_PWD }}
+      PAT: ${{ secrets.PAT }}
 
   build-test-publish-wheel:
     needs: bump

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -112,6 +112,14 @@ on:
         description: Skip the test wheel step
         type: boolean
         default: false
+      skip-wheel-build:
+        required: false
+        description: |
+          Skip the entire wheel build phase. Use for repos whose wheel build
+          requires infrastructure not available in this orchestration (e.g.
+          CUDA-only dependencies). Bump and finalize still run.
+        type: boolean
+        default: false
       custom-container:
         required: false
         description: Custom container to use for the build
@@ -248,6 +256,7 @@ jobs:
         success() || !failure()
       )
       && !cancelled()
+      && inputs.skip-wheel-build == false
     with:
       no-publish: ${{ inputs.validate-only || inputs.dry-run }}
       suppress-failure-notify: ${{ inputs.validate-only }}

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -495,6 +495,7 @@ jobs:
       && !cancelled()
     with:
       no-publish: ${{ inputs.validate-only || inputs.dry-run }}
+      suppress-failure-notify: ${{ inputs.validate-only }}
       python-package: ${{ inputs.python-package }}
       python-version: ${{ inputs.python-version }}
       ref: ${{ inputs.release-ref }}
@@ -688,10 +689,10 @@ jobs:
       (
         success() || !failure()
       )
-      && inputs.publish-docs == true
+      && (inputs.publish-docs == true || inputs.validate-only == true)
       && !cancelled()
     with:
-      ref: ${{ inputs.gh-release-tag-prefix || '' }}v${{ needs.build-test-publish-wheel.outputs.version }}
+      ref: ${{ inputs.validate-only && inputs.release-ref || format('{0}v{1}', inputs.gh-release-tag-prefix || '', needs.build-test-publish-wheel.outputs.version) }}
 
   publish-docs:
     needs: [build-test-publish-wheel, create-gh-release, build-docs]

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -128,8 +128,11 @@ on:
         type: boolean
         default: false
       app-id:
-        required: true
-        description: GitHub App ID
+        required: false
+        default: ""
+        description: |
+          GitHub App ID for minting the bot token used by bump-next-version.
+          Empty falls back to `secrets.PAT` for git push and PR creation.
         type: string
       root-dir:
         required: false

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -136,11 +136,8 @@ on:
         type: boolean
         default: false
       app-id:
-        required: false
-        default: ""
-        description: |
-          GitHub App ID for minting the bot token used by bump-next-version.
-          Empty falls back to `secrets.PAT` for git push and PR creation.
+        required: true
+        description: GitHub App ID for minting the bot token used by bump-next-version.
         type: string
       root-dir:
         required: false
@@ -246,7 +243,6 @@ jobs:
       BOT_KEY: ${{ secrets.BOT_KEY }}
       SSH_KEY: ${{ secrets.SSH_KEY }}
       SSH_PWD: ${{ secrets.SSH_PWD }}
-      PAT: ${{ secrets.PAT }}
 
   build-test-publish-wheel:
     needs: bump

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -184,6 +184,16 @@ on:
         description: Skip the publish step unless the workflow is running on a version tag.
         type: boolean
         default: false
+      docs-root-dir:
+        required: false
+        description: Sub-directory of docs source pyproject.toml. Defaults to root-dir; override for monorepos with repo-root docs.
+        type: string
+        default: ""
+      docs-requirements-file:
+        required: false
+        description: pip-installable requirements.txt for docs install (instead of uv sync --only-group docs).
+        type: string
+        default: ""
       container-options:
         required: false
         description: Options to pass to the container
@@ -316,6 +326,8 @@ jobs:
       publish-as-latest: ${{ inputs.publish-as-latest }}
       update-version-picker: ${{ inputs.update-version-picker }}
       run-on-version-tag-only: ${{ inputs.run-on-version-tag-only }}
+      docs-root-dir: ${{ inputs.docs-root-dir }}
+      docs-requirements-file: ${{ inputs.docs-requirements-file }}
       notify-emails: ${{ inputs.notify-emails }}
       root-dir: ${{ inputs.root-dir }}
       app-id: ${{ inputs.app-id }}


### PR DESCRIPTION
## Design issues addressed

| # | Issue | Solution |
|---|-------|----------|
| 1 | **Coverage drift.** PR runs only exercised the wheel build. Bump, GH-release, docs-build paths broke for the first time at real-release time. | New `validate-only` mode runs the full release pipeline inert (no PyPI, no PR push, no GH release POST, no docs publish, no Slack). PRs now rehearse what ships. |
| 2 | **TestPyPI bloat.** `dry-run` uploaded to TestPyPI on every push to main / release branches. Quota fills up. | Drop TestPyPI entirely. Metadata compliance now checked locally via `twine check` + `check-wheel-contents` + `check-manifest`. |
| 3 | **Pin drift.** Two separate caller files (`build-test-publish-wheel.yml` for PRs, `release.yaml` for releases) each pinned FW-CI-templates independently. The version tested on PR was rarely the version that shipped. | Single consumer file. `validate-only` is derived from the trigger; one pin governs both PR rehearsal and real release. |
| 4 | **Multi-wheel consumers couldn't use the shared orchestration.** Megatron-LM publishes two PyPI projects with a custom multi-arch matrix; the monolithic `_release_library.yml` couldn't accommodate this without forking ~500 lines of YAML. | Decompose into composable reusable workflows: `_release_bump.yml` (multi-target capable), `_release_finalize.yml`, plus the existing `_build_test_publish_wheel.yml`. Single-wheel consumers keep using `_release_library.yml` (now a thin wrapper). Multi-wheel consumers compose at the consumer level. |
| 5 | **Mixed auth: PAT vs GitHub App.** Some consumers used a personal access token (PAT) for git push + PR creation; others used a GitHub App. The branching auth path doubled the surface area in `_release_bump.yml` (PAT fallback, conditional GPG signing, hybrid commit identity) and obscured which identity the bump commits ran under. | Drop PAT support entirely. `_release_bump.yml` requires `app-id` + `BOT_KEY`; auth is always the GitHub App bot token. Consumers must configure `vars.BOT_ID` and `secrets.BOT_KEY` (org-level `BOT_ID` already covers most repos). |
| 6 | **GPG signing for the bump commit required two extra per-repo secrets** (`SSH_KEY`, `SSH_PWD`) that nothing else in the pipeline used. Setting them up correctly was a recurring onboarding tax with little payoff — the bump commit is a bot-authored mechanical edit, not a thing a human reviews for cryptographic provenance. | Drop GPG signing from `_release_bump.yml`. The bump commit is now committed under the `github-actions[bot]` identity with `-s` (signoff) only; the App-token authorizes the push. `SSH_KEY` and `SSH_PWD` are no longer accepted as secrets; consumers should remove them from their `release.yaml` `secrets:` blocks at the next pin bump. |

## Workflow composition

**Single-wheel consumer** (Megatron-Bridge, NeMo, NeMo-RL, NeMo-Curator):

```mermaid
flowchart LR
    T[push or workflow_dispatch] --> PF[pre-flight]
    PF --> W["_release_library.yml<br/>(wrapper)"]
    subgraph W [ ]
      direction LR
      B["_release_bump.yml"] --> WH["_build_test_publish_wheel.yml"] --> F["_release_finalize.yml"]
    end
    W --> S[release-summary]
```

`validate-only` is set from the trigger (`true` on push, `false` on workflow_dispatch).
External interface unchanged — existing consumers need no code change beyond the pin bump.

**Multi-wheel consumer** (Megatron-LM): two PyPI projects (`megatron-core`, `megatron_fsdp`), three wheel cells (core arm64+amd64, fsdp amd64), each producing cp311+cp312+cp313 manylinux wheels. Composed at the consumer level:

```mermaid
flowchart LR
    T[push or workflow_dispatch] --> PF[pre-flight push only]
    PF --> B["FW-CI-templates<br/>_release_bump.yml<br/>(multi-target)"]
    B --> WH["consumer-local<br/>_build_test_publish_wheel.yml<br/>(manylinux matrix)"]
    WH --> F["FW-CI-templates<br/>_release_finalize.yml"]
    F --> PD["consumer-local<br/>release-docs.yml"]
    PD --> S[release-summary]
```

`bump-targets` JSON input lets one bump commit cover both packages. `_release_finalize.yml` takes `release-version` from the bump output, so the consumer can sandwich its own wheel and docs jobs between the two phases.

## Technical drilldown

### `_release_bump.yml` (new)

```mermaid
flowchart LR
    A["check-admin-permission<br/><i>advisory if validate-only</i>"] --> B[bump-next-version]
    B --> B1["compute<br/>release-version<br/>+ next-version"]
    B1 --> B2["push tmp branch<br/>+ open PR"]
    B2 --> B3[wait for status checks]
    B3 --> B4["merge into<br/>version-bump-branch"]
    B4 --> B5[delete tmp branch]
    B1 -.->|validate-only| Out[done — write to step summary]
    B4 -.->|validate-only OR dry-run| EchoMerge[echo push command]
```

- **Targets**: JSON array `bump-targets: [{python-package, src-dir}, ...]`. Single-target consumers keep using `python-package` + `has-src-dir`; that path falls through to a one-element array internally.
- **Auth**: GitHub App only (`actions/create-github-app-token`, requires `app-id` + `BOT_KEY`). The bump commit is unsigned, authored by `github-actions[bot]`, signed off with `-s`. The App token authorizes the push and the PR creation.
- **Outputs**: `release-version` (current, what's being released) and `next-version` (post-bump, used in PR title and summary).
- **Inert mode**: `validate-only` skips everything past the version compute (the branch-cycle is the only thing that distinguishes PR rehearsal from `workflow_dispatch dry-run=true`). `dry-run` (validate-only=false) still pushes the tmp branch + PR + status wait + cleanup, but echoes the final merge.

### `_release_finalize.yml` (new)

```mermaid
flowchart LR
    C[create-gh-release] --> D[build-docs]
    C --> N[notify]
    D --> P[publish-docs]
    C -.->|validate-only OR dry-run| EchoCurl[echo curl payload]
    D -.->|publish-docs=false| SkipD[skipped]
    P -.->|validate-only OR dry-run| EchoSync[aws s3 sync --dryrun]
    N -.->|validate-only| Summary[render to step summary]
```

- **Inputs**: `release-version` and `pypi-name` come from upstream jobs (bump + wheel) — finalize is agnostic to how the wheel was built. This decoupling is what enables consumer-local wheel matrices.
- **Inert gate**: `IS_INERT = validate-only OR dry-run`. `create-gh-release` echoes the curl POST under `IS_INERT`.
- **Docs**: `build-docs` and `publish-docs` always run when `publish-docs=true`. The underlying `publish-docs` action's `dry-run` flag is wired to `IS_INERT`, so `aws s3 sync` is skipped on PR rehearsal. Consumers with monorepo layouts can pass `docs-root-dir` (where the docs `pyproject.toml` lives) and `docs-requirements-file` (pip-install style instead of `uv sync --only-group docs`).
- **Notify**: posts to Slack only on `workflow_dispatch` (dry-run prefix when `dry-run=true`). Validate-only renders the assembled message to `$GITHUB_STEP_SUMMARY` so we still validate the build-step's shell logic without spamming the channel.
- **Resilience**: all secrets are `required: false`; the CHANGELOG.md read is guarded by `[[ -f CHANGELOG.md ]]` with a placeholder fallback.

### `_release_library.yml` (refactored as wrapper)

```mermaid
flowchart LR
    B[bump<br/>_release_bump.yml] --> W[build-test-publish-wheel<br/>_build_test_publish_wheel.yml]
    W --> F[finalize<br/>_release_finalize.yml]
    F --> Out["release-version<br/>= bump.outputs.release-version<br/>OR wheel.outputs.version"]
```

- ~80 lines, pure plumbing.
- Inner workflows referenced via `./.github/workflows/...` so they always travel together at the same FW-CI-templates ref.
- External interface preserved — existing single-wheel consumers bump only the pin; their `with:` / `secrets:` blocks stay byte-identical.
- The deleted `build-test-publish-wheel-dry-run` job (old TestPyPI smoke test) is replaced by per-PR validate-only — same code path, every push, instead of once per release.

## Breaking change

`_build_test_publish_wheel.yml` no longer accepts `dry-run`. To skip publishing, use `no-publish: true`.

## Companion PRs

| Repo | PR | Wheel build | Notes |
|------|----|-------------|-------|
| Megatron-Bridge | NVIDIA-NeMo/Megatron-Bridge#3658 | shared (NGC pytorch container) | wrapper consumer |
| Megatron-LM | NVIDIA/Megatron-LM#4602 | consumer-local manylinux matrix | multi-wheel (`megatron-core` + `megatron_fsdp`) |
| Automodel | NVIDIA-NeMo/Automodel#2127 | shared (linux-amd64-cpu16) | wrapper consumer |
| NeMo-Curator | NVIDIA-NeMo/Curator#1911 | shared (ubuntu-latest) | wrapper consumer; docs handled by Fern (FW-CI publish-docs skipped) |
| NeMo-RL | NVIDIA-NeMo/RL#2397 | n/a (`skip-wheel-build: true`) | wrapper consumer; `pull_request:` trigger used (no copy-pr-bot mirror) |
| NeMo-Run | NVIDIA-NeMo/Run#502 | shared (ubuntu-latest) | wrapper consumer; setuptools-dynamic packaging |
| NeMo-Export-Deploy | NVIDIA-NeMo/Export-Deploy#663 | shared (NGC pytorch container) | wrapper consumer; multi-toplevel wheel (`wheel-content-ignore: W009`) |
| NeMo-Evaluator | NVIDIA-NeMo/Evaluator#962 | shared, two parallel calls | wrapper consumer (two PyPI projects: `nemo-evaluator` + `nemo-evaluator-launcher`); monorepo (`docs-root-dir: "."`, `docs-requirements-file`) |
| Emerging-Optimizers | NVIDIA-NeMo/Emerging-Optimizers#176 | n/a (`skip-wheel-build: true`) | wrapper consumer; no PyPI publish (same pattern as NeMo-RL) |
| NeMo-Gym | NVIDIA-NeMo/Gym#1242 | shared (ubuntu-latest) | wrapper consumer; uv packaging |
| NeMo | NVIDIA-NeMo/NeMo#15668 | shared (ubuntu-latest) | wrapper consumer; largest consumer; bumped from FW-CI v0.80.3 |

## Test plan

- [x] Phase 1 validate-only on push (MB#3658)
- [x] Phase 1 dry-run dispatch (MB)
- [x] Phase 2 wrapper preserves single-wheel behavior (MB#3658, post-rebase)
- [x] Phase 2 multi-wheel push rehearsal (MLM#4602)
- [x] Phase 2 multi-wheel dry-run dispatch (MLM)
- [x] PR-push rehearsal across all 8 consumer PRs.
- [x] Dry-run dispatch across all 8 consumer PRs.
- [ ] Path C verification via the next planned RC release.

## Rollout

1. Merge this PR.
2. Cut FW-CI-templates `v1.0.0` (drops `dry-run` from `_build_test_publish_wheel.yml`).
3. Bump the consumer PR pins from SHA → tag and merge.
4. Future single-wheel consumers adopt the consolidated single-caller pattern.