### PR TITLE
fix: improve approved-unmerged PR detection and add GraphQL retry

### DIFF
--- a/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
+++ b/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
@@ -549,19 +549,33 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
             target_branch = ""
             is_draft = False
             last_approval_date = ""
-            has_changes_requested = False
+            all_reviewers_approved = False
             if item_type == "PullRequest":
                 target_branch = content.get("baseRefName", "")
                 is_draft = content.get("isDraft", False)
 
-                # Find the latest approval date and whether changes were requested
+                # Track each reviewer's latest review state
+                reviewer_latest: dict[str, tuple[str, str]] = {}  # login -> (state, submittedAt)
                 for review in content.get("reviews", {}).get("nodes", []):
-                    if review.get("state") == "APPROVED":
-                        submitted = review.get("submittedAt", "")
-                        if submitted > last_approval_date:
-                            last_approval_date = submitted
-                    elif review.get("state") == "CHANGES_REQUESTED":
-                        has_changes_requested = True
+                    reviewer_obj = review.get("author", {}) or {}
+                    reviewer_login = reviewer_obj.get("login", "")
+                    submitted = review.get("submittedAt", "")
+                    state = review.get("state", "")
+                    if not reviewer_login or not state:
+                        continue
+                    prev = reviewer_latest.get(reviewer_login)
+                    if prev is None or submitted > prev[1]:
+                        reviewer_latest[reviewer_login] = (state, submitted)
+
+                # Find the latest approval date
+                for login, (state, submitted) in reviewer_latest.items():
+                    if state == "APPROVED" and submitted > last_approval_date:
+                        last_approval_date = submitted
+
+                # Only treat as fully approved if every reviewer's latest state is APPROVED
+                all_reviewers_approved = bool(reviewer_latest) and all(
+                    state == "APPROVED" for state, _ in reviewer_latest.values()
+                )
 
             repo_name = content.get("repository", {}).get("name", "")
             issue_number = content.get("number")
@@ -604,12 +618,14 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
                 item_dict["needs_attention"] = classification == "waiting-on-maintainers" and is_stale
 
                 # Approved PRs not merged after 48 hours need follow-up,
-                # unless a reviewer has requested changes — in that case,
-                # defer to the LLM classification (the ball may be with the author).
-                if item_type == "PullRequest" and last_approval_date:
+                # but only if ALL reviewers' latest reviews are approvals.
+                # If any reviewer's latest state is not APPROVED (e.g.
+                # changes requested, commented, dismissed), defer to the
+                # LLM classification instead.
+                if item_type == "PullRequest" and last_approval_date and all_reviewers_approved:
                     approval_dt = datetime.fromisoformat(last_approval_date.replace("Z", "+00:00"))
                     approval_stale = approval_dt < datetime.now(timezone.utc) - timedelta(hours=48)
-                    if approval_stale and not has_changes_requested:
+                    if approval_stale:
                         item_dict["needs_attention"] = True
 
                 print(f"  {item_dict['url']}: {classification} (stale={is_stale}, approved_unmerged={'48h+' if item_type == 'PullRequest' and last_approval_date and item_dict['needs_attention'] else 'n/a'})")

--- a/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
+++ b/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
@@ -27,6 +27,7 @@ Requires the following environment variables:
 import argparse
 import csv
 import os
+import time
 from datetime import datetime, timedelta, timezone
 
 import openai
@@ -73,33 +74,41 @@ question or request directed at the maintainers.
 Respond with ONLY "waiting-on-author" or "waiting-on-maintainers", nothing else."""
 
 
-def run_graphql_query(query: str, variables: dict, token: str) -> dict:
-    """Execute a GraphQL query against GitHub's API."""
+def run_graphql_query(query: str, variables: dict, token: str, max_retries: int = 5) -> dict:
+    """Execute a GraphQL query against GitHub's API with exponential backoff."""
     headers = {
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
     }
 
-    response = requests.post(
-        GITHUB_GRAPHQL_URL,
-        json={"query": query, "variables": variables},
-        headers=headers,
-    )
+    for attempt in range(max_retries + 1):
+        response = requests.post(
+            GITHUB_GRAPHQL_URL,
+            json={"query": query, "variables": variables},
+            headers=headers,
+        )
 
-    if response.status_code != 200:
+        if response.status_code == 200:
+            result = response.json()
+
+            if "errors" in result:
+                print("GraphQL errors:")
+                for error in result["errors"]:
+                    print(f"  - {error.get('message', error)}")
+                raise RuntimeError("GraphQL query returned errors")
+
+            return result
+
+        # Retry on server errors (5xx) and rate limits (403, 429)
+        if response.status_code in (403, 429, 500, 502, 503, 504) and attempt < max_retries:
+            delay = 2 ** attempt  # 1s, 2s, 4s, 8s, 16s
+            print(f"  Retrying in {delay}s after HTTP {response.status_code} (attempt {attempt + 1}/{max_retries})...")
+            time.sleep(delay)
+            continue
+
         print(f"Error: GitHub API returned status code {response.status_code}")
         print(f"Response: {response.text}")
         raise RuntimeError("GraphQL query request failed")
-
-    result = response.json()
-
-    if "errors" in result:
-        print("GraphQL errors:")
-        for error in result["errors"]:
-            print(f"  - {error.get('message', error)}")
-        raise RuntimeError("GraphQL query returned errors")
-
-    return result
 
 
 def ensure_label_exists(org: str, repo: str, label_name: str, label_color: str, label_description: str, token: str) -> bool:

--- a/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
+++ b/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
@@ -549,16 +549,19 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
             target_branch = ""
             is_draft = False
             last_approval_date = ""
+            has_changes_requested = False
             if item_type == "PullRequest":
                 target_branch = content.get("baseRefName", "")
                 is_draft = content.get("isDraft", False)
 
-                # Find the latest approval date
+                # Find the latest approval date and whether changes were requested
                 for review in content.get("reviews", {}).get("nodes", []):
                     if review.get("state") == "APPROVED":
                         submitted = review.get("submittedAt", "")
                         if submitted > last_approval_date:
                             last_approval_date = submitted
+                    elif review.get("state") == "CHANGES_REQUESTED":
+                        has_changes_requested = True
 
             repo_name = content.get("repository", {}).get("name", "")
             issue_number = content.get("number")
@@ -600,11 +603,13 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
                 is_stale = comment_dt < datetime.now(timezone.utc) - timedelta(hours=48)
                 item_dict["needs_attention"] = classification == "waiting-on-maintainers" and is_stale
 
-                # Approved PRs not merged after 48 hours always need follow-up
+                # Approved PRs not merged after 48 hours need follow-up,
+                # unless a reviewer has requested changes — in that case,
+                # defer to the LLM classification (the ball may be with the author).
                 if item_type == "PullRequest" and last_approval_date:
                     approval_dt = datetime.fromisoformat(last_approval_date.replace("Z", "+00:00"))
                     approval_stale = approval_dt < datetime.now(timezone.utc) - timedelta(hours=48)
-                    if approval_stale:
+                    if approval_stale and not has_changes_requested:
                         item_dict["needs_attention"] = True
 
                 print(f"  {item_dict['url']}: {classification} (stale={is_stale}, approved_unmerged={'48h+' if item_type == 'PullRequest' and last_approval_date and item_dict['needs_attention'] else 'n/a'})")

--- a/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
+++ b/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
@@ -563,14 +563,15 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
                 target_branch = content.get("baseRefName", "")
                 is_draft = content.get("isDraft", False)
 
-                # Track each reviewer's latest review state
+                # Track each non-bot reviewer's latest review state
                 reviewer_latest: dict[str, tuple[str, str]] = {}  # login -> (state, submittedAt)
                 for review in content.get("reviews", {}).get("nodes", []):
                     reviewer_obj = review.get("author", {}) or {}
                     reviewer_login = reviewer_obj.get("login", "")
+                    reviewer_type = reviewer_obj.get("__typename", "")
                     submitted = review.get("submittedAt", "")
                     state = review.get("state", "")
-                    if not reviewer_login or not state:
+                    if not reviewer_login or not state or reviewer_type == "Bot":
                         continue
                     prev = reviewer_latest.get(reviewer_login)
                     if prev is None or submitted > prev[1]:


### PR DESCRIPTION
## Summary
- **Only override LLM classification when all human reviewers have approved**: Previously, any PR with an approval stale for 48h+ was unconditionally flagged as needing maintainer attention. Now, each reviewer's latest review state is tracked and the override only applies when every human reviewer's most recent review is `APPROVED`. If any reviewer has a non-approval state (changes requested, commented, dismissed), the LLM classification is used instead.
- **Exclude bot users from reviewer approval check**: Bot reviewers (e.g. CI bots) no longer count when determining whether all reviewers have approved.
- **Add exponential backoff to GitHub GraphQL queries**: Retry on transient server errors (5xx) and rate limits (403, 429) with exponential backoff (1s, 2s, 4s, 8s, 16s) instead of crashing mid-pagination.

## Test plan
- [x] Ran script in debug mode (no label updates) against project #20 with the old logic (`debug_output.csv`) and compared against the new logic (`debug_output_v3.csv`)
- [x] Verified 8 PRs correctly flipped from forced `waiting-on-maintainers` to LLM-classified `waiting-on-author` where not all human reviewers approved
- [x] Verified bot exclusion prevents CI bots from incorrectly inflating or deflating the approval count
- [x] Confirmed the remaining ~20 approved-unmerged PRs where all human reviewers approved still get the override correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)