### PR TITLE
fix: Bump actions to address node 20 warning

### DIFF
--- a/.github/workflows/_build_docs.yml
+++ b/.github/workflows/_build_docs.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.0.1
 
       - name: Install dependencies
         env:

--- a/.github/workflows/_build_docs.yml
+++ b/.github/workflows/_build_docs.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.0.1
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install dependencies
         env:

--- a/.github/workflows/_cicd_preflight.yml
+++ b/.github/workflows/_cicd_preflight.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: step-security/changed-files@v45.0.1
+        uses: step-security/changed-files@v47.0.5
         with:
           base_sha: ${{ steps.base-ref.outputs.base }}
           files_yaml: |

--- a/.github/workflows/_copyright_check.yml
+++ b/.github/workflows/_copyright_check.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: step-security/changed-files@v45.0.1
+        uses: step-security/changed-files@v47.0.5
         with:
           sha: ${{ steps.get-sha.outputs.sha }}
           base_sha: ${{ steps.get-sha.outputs.base_sha }}


### PR DESCRIPTION
fix: Bump actions to address node 20 warning

A few actions need to be updated to address the node 20 deprecation warning:
* step-security/changed-files
* astral/setup-uv