### PR TITLE
feat: plumb docs-sync-all input through release workflows

### DIFF
--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -124,6 +124,11 @@ on:
         description: Skip Sphinx linkcheck. Use until the repo curates a `broken_links_false_positives.json`.
         type: boolean
         default: false
+      docs-sync-all:
+        required: false
+        description: "Sync all dependency groups (not just docs) before building. Use when conf.py imports the package."
+        type: boolean
+        default: false
       notify-emails:
         required: false
         type: string
@@ -310,6 +315,7 @@ jobs:
       docs-directory: ${{ inputs.docs-directory }}
       fail-on-warning: ${{ inputs.docs-fail-on-warning }}
       skip-linkcheck: ${{ inputs.docs-skip-linkcheck }}
+      sync-all: ${{ inputs.docs-sync-all }}
 
   publish-docs:
     needs: [create-gh-release, build-docs]

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -214,6 +214,11 @@ on:
         description: Skip Sphinx linkcheck.
         type: boolean
         default: false
+      docs-sync-all:
+        required: false
+        description: Sync all dependency groups (not just docs) before building.
+        type: boolean
+        default: false
       container-options:
         required: false
         description: Options to pass to the container
@@ -345,6 +350,7 @@ jobs:
       docs-directory: ${{ inputs.docs-directory }}
       docs-fail-on-warning: ${{ inputs.docs-fail-on-warning }}
       docs-skip-linkcheck: ${{ inputs.docs-skip-linkcheck }}
+      docs-sync-all: ${{ inputs.docs-sync-all }}
       notify-emails: ${{ inputs.notify-emails }}
       root-dir: ${{ inputs.root-dir }}
       app-id: ${{ inputs.app-id }}


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Adds `docs-sync-all` input to `_release_library.yml` and `_release_finalize.yml`, plumbed through to the underlying `_build_docs.yml@sync-all` parameter.

Use case: repos whose `conf.py` imports the package itself (Sphinx autodoc) need all dependency groups, not just `docs`.

```yaml
# Consumer release.yaml
release:
  uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@vX.Y.Z
  with:
    docs-sync-all: true   # NEW
```

## Test plan

- [ ] Bump pin in NVIDIA-NeMo/Emerging-Optimizers#176 to this SHA + add `docs-sync-all: true` and confirm the docs build picks up the package's runtime deps.

</details>
