### PR TITLE
feat(release): forward docs-no-extras through release-library

### DIFF
--- a/.github/workflows/_release_finalize.yml
+++ b/.github/workflows/_release_finalize.yml
@@ -129,6 +129,11 @@ on:
         description: "Sync all dependency groups (not just docs) before building. Use when conf.py imports the package."
         type: boolean
         default: false
+      docs-no-extras:
+        required: false
+        description: Space-separated `--no-extra <name>` flags to skip optional extras when syncing all groups (only used when docs-sync-all is true).
+        type: string
+        default: ""
       notify-emails:
         required: false
         type: string
@@ -316,6 +321,7 @@ jobs:
       fail-on-warning: ${{ inputs.docs-fail-on-warning }}
       skip-linkcheck: ${{ inputs.docs-skip-linkcheck }}
       sync-all: ${{ inputs.docs-sync-all }}
+      no-extras: ${{ inputs.docs-no-extras }}
 
   publish-docs:
     needs: [create-gh-release, build-docs]

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -219,6 +219,11 @@ on:
         description: Sync all dependency groups (not just docs) before building.
         type: boolean
         default: false
+      docs-no-extras:
+        required: false
+        description: Space-separated `--no-extra <name>` flags to skip optional extras when syncing all groups (only used when docs-sync-all is true).
+        type: string
+        default: ""
       container-options:
         required: false
         description: Options to pass to the container
@@ -351,6 +356,7 @@ jobs:
       docs-fail-on-warning: ${{ inputs.docs-fail-on-warning }}
       docs-skip-linkcheck: ${{ inputs.docs-skip-linkcheck }}
       docs-sync-all: ${{ inputs.docs-sync-all }}
+      docs-no-extras: ${{ inputs.docs-no-extras }}
       notify-emails: ${{ inputs.notify-emails }}
       root-dir: ${{ inputs.root-dir }}
       app-id: ${{ inputs.app-id }}


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Why

`_build_docs.yml` already accepts `no-extras` (used to skip optional extras like `--no-extra cu12` when running `uv sync --all-groups`). `_release_library.yml` exposes `docs-sync-all` as of v1.1.0 but does **not** forward a `no-extras` equivalent — so consumers calling the release library cannot get parity with their standalone `build-docs.yml`.

Discovered while migrating NVIDIA-NeMo/NeMo to call `_release_library@v1.x` from a single `release.yml`: the existing `build-docs.yml` there uses both `sync-all: true` and `no-extras: "--no-extra cu12"`, but the release-library path drops `no-extras` and falls back to a full `--all-extras` sync, which fails to install on the docs runner.

## What

- Add a `docs-no-extras` input on `_release_library.yml` (forwards to `_release_finalize.yml`).
- Add a `docs-no-extras` input on `_release_finalize.yml` (forwards to `_build_docs.yml`'s `no-extras`).
- Mirrors the existing `docs-sync-all` wiring exactly. No change to defaults — empty string preserves current behavior.

```yaml
# example consumer (NeMo release.yml)
uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@<this-tag>
with:
  ...
  docs-sync-all: true
  docs-no-extras: "--no-extra cu12"
```

## Test plan

- [ ] CI on this branch (workflow validation).
- [ ] Cut a tag once merged and bump NVIDIA-NeMo/NeMo#15668 to consume it.

</details>
