### PR TITLE
fix: bump peter-evans/create-pull-request v6 to v8

### DIFF
--- a/.github/workflows/_bump_dockerfile.yml
+++ b/.github/workflows/_bump_dockerfile.yml
@@ -71,7 +71,7 @@ jobs:
           sed -i 's/^ARG ${{ inputs.build-arg }}=.*$/ARG ${{ inputs.build-arg }}=${{ steps.ref.outputs.sha }}/' ${{ inputs.dockerfile }}
 
       - name: Create Bump PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         id: create-pull-request
         env:
           title: 'chore(beep boop 🤖): Bump `${{ inputs.build-arg }}=${{ steps.ref.outputs.short_sha }}...` (${{ steps.ref.outputs.date }})'

--- a/.github/workflows/_bump_file.yml
+++ b/.github/workflows/_bump_file.yml
@@ -72,7 +72,7 @@ jobs:
           sed -i 's/\(.* ${{ inputs.argument }}=\).*/\1${{ steps.ref.outputs.sha }}/' ${{ inputs.file }}
 
       - name: Create Bump PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         id: create-pull-request
         env:
           title: 'chore(beep boop 🤖): Bump `${{ inputs.argument }}=${{ steps.ref.outputs.short_sha }}...` (${{ steps.ref.outputs.date }})'

--- a/.github/workflows/_bump_tomlfile.yml
+++ b/.github/workflows/_bump_tomlfile.yml
@@ -112,7 +112,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Create Bump PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         id: create-pull-request
         env:
           default-title: "chore(🤖): Bump `${{ inputs.source-repository }}` to `${{ steps.ref.outputs.short_sha }}...` (${{ steps.ref.outputs.date }})"

--- a/.github/workflows/_bump_yamlfile.yml
+++ b/.github/workflows/_bump_yamlfile.yml
@@ -119,7 +119,7 @@ jobs:
           git_commit_gpgsign: true
 
       - name: Create Bump PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         id: create-pull-request
         env:
           default-title: "chore(🤖): Bump `${{ inputs.source-repository }}` to `${{ steps.ref.outputs.short_sha }}...` (${{ steps.ref.outputs.date }})"

--- a/.github/workflows/_code_freeze.yml
+++ b/.github/workflows/_code_freeze.yml
@@ -179,7 +179,7 @@ jobs:
           echo "version=$NEXT_MAJOR.$NEXT_MINOR.$NEXT_PATCH$NEXT_PRERELEASE.$NEXT_DEV" | tee -a "$GITHUB_OUTPUT"
 
       - name: Create Version Bump PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         id: create-pull-request
         if: ${{ inputs.dry-run != true }}
         with:


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background

The `code-freeze` reusable workflow's `bump-next-version` job failed in [Megatron-LM run 26786250240](https://github.com/NVIDIA/Megatron-LM/actions/runs/26786250240) with:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/NVIDIA/Megatron-LM/': The requested URL returned error: 400
##[error]The process '/usr/bin/git' failed with exit code 128
```

Two `Authorization` headers were sent on the git push: one from `actions/checkout`'s `http.https://github.com/.extraheader`, and a second from `peter-evans/create-pull-request@v6`'s PAT handling. `peter-evans/create-pull-request@v8` ships `actions/checkout@v6` internally with reworked credential handling that no longer collides.

#483 fixes this for `_code_freeze.yml` only via `persist-credentials: false`. This PR is complementary: the same v6 pin lives in four other reusable workflows, all of which can hit the same bug.

## What changed

- Bump `peter-evans/create-pull-request@v6` → `@v8` in 5 reusable workflows.

## Details

| File | Line |
|---|---|
| `.github/workflows/_code_freeze.yml` | 182 |
| `.github/workflows/_bump_dockerfile.yml` | 74 |
| `.github/workflows/_bump_file.yml` | 75 |
| `.github/workflows/_bump_tomlfile.yml` | 115 |
| `.github/workflows/_bump_yamlfile.yml` | 122 |

v7 renamed the `git-token` input to `branch-token`. Verified via `grep` — no workflow in this repo uses either, so no input migration is required. v8's only breaking change vs v7 is the Node 24 runtime requirement (Actions Runner ≥ v2.327.1), already satisfied by GitHub-hosted runners.

## Tested

- `grep -rn "peter-evans/create-pull-request" .github/workflows/` → all 5 sites now `@v8`.
- `grep -rn "git-token\|branch-token" .github/workflows/` → no matches; no input rename needed.

</details>
