### PR TITLE
fix: make code-freeze next-version pre-release/dev tags configurable

### DIFF
--- a/.github/workflows/_code_freeze.yml
+++ b/.github/workflows/_code_freeze.yml
@@ -52,6 +52,16 @@ on:
         description: "Prefix for the release branch name (e.g. 'core_' results in 'core_rX.Y.Z')"
         type: string
         default: ""
+      next-pre-release:
+        required: false
+        description: "Pre-release tag for the next dev version bumped on main (e.g. 'rc0'); pass an empty string for clean semver"
+        type: string
+        default: rc0
+      next-dev:
+        required: false
+        description: "Dev tag for the next dev version bumped on main (e.g. 'dev0'); pass an empty string to omit it"
+        type: string
+        default: dev0
     secrets:
       SLACK_WEBHOOK:
         required: true
@@ -146,6 +156,8 @@ jobs:
         id: bump-version
         env:
           PACKAGING: ${{ inputs.packaging }}
+          NEXT_PRERELEASE: ${{ inputs.next-pre-release }}
+          NEXT_DEV: ${{ inputs.next-dev }}
         run: |
           cd ${{ github.run_id }}
 
@@ -163,8 +175,11 @@ jobs:
           fi
 
           NEXT_PATCH=0
-          NEXT_PRERELEASE=rc0
-          NEXT_DEV=dev0
+
+          NEXT_VERSION="$NEXT_MAJOR.$NEXT_MINOR.$NEXT_PATCH$NEXT_PRERELEASE"
+          if [[ -n "$NEXT_DEV" ]]; then
+            NEXT_VERSION="$NEXT_VERSION.$NEXT_DEV"
+          fi
 
           if [[ "$PACKAGING" == "setuptools" ]]; then
             sed -i "/^MAJOR/c\MAJOR = $NEXT_MAJOR" package_info.py
@@ -173,10 +188,10 @@ jobs:
             sed -i "/^PRE_RELEASE/c\PRE_RELEASE = '$NEXT_PRERELEASE'" package_info.py
             sed -i "/^DEV/c\DEV = '$NEXT_DEV'" package_info.py
           elif [[ "$PACKAGING" == "hatch" ]]; then
-            sed -i "/^__version__/c\__version__ = '$NEXT_MAJOR.$NEXT_MINOR.$NEXT_PATCH$NEXT_PRERELEASE.$NEXT_DEV'" package_info.py
+            sed -i "/^__version__/c\__version__ = '$NEXT_VERSION'" package_info.py
           fi
 
-          echo "version=$NEXT_MAJOR.$NEXT_MINOR.$NEXT_PATCH$NEXT_PRERELEASE.$NEXT_DEV" | tee -a "$GITHUB_OUTPUT"
+          echo "version=$NEXT_VERSION" | tee -a "$GITHUB_OUTPUT"
 
       - name: Create Version Bump PR
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- The `bump-next-version` job in `_code_freeze.yml` **hardcoded** `NEXT_PRERELEASE=rc0` and `NEXT_DEV=dev0`.
- Repos that moved to clean semver re-acquire an `rc0` tag on `main` every freeze. Export-Deploy dropped `rc0` in favor of dynamic git versioning (`PRE_RELEASE = ""`, NVIDIA-NeMo/Export-Deploy#648), but the freeze bumped `main` back to `0.7.0rc0` — forcing a manual revert of the bump PR (NVIDIA-NeMo/Export-Deploy#703, commit `9dde413`).
- Export-Deploy's `package_info.py` also has **no `DEV` field**, so `dev0` only ever surfaced in the branch name / PR title / version output (`0.7.0rc0.dev0`) while the file said `0.7.0rc0` — a second inconsistency.

## What changed

- Add two optional inputs: `next-pre-release` (default `rc0`) and `next-dev` (default `dev0`).
- Compose the next-version string conditionally so an empty `next-dev` doesn't leave a trailing `.`.

## Details

- `.github/workflows/_code_freeze.yml`:
  - New `workflow_call` inputs `next-pre-release` / `next-dev` — defaults preserve the current `rc0`/`dev0` behavior, so **no existing consumer is affected**.
  - Wired into the `bump-version` step via the `env:` block (`NEXT_PRERELEASE`, `NEXT_DEV`) instead of hardcoded shell assignments.
  - `NEXT_VERSION` is built as `MAJOR.MINOR.PATCH<pre>` and `.<dev>` is appended only when `next-dev` is non-empty. Used for both the `hatch` `__version__` rewrite and the `version` output.

## Example

A clean-semver repo (no `rc0`, no `dev` field) opts in from its caller workflow:

```yaml
jobs:
  code-freeze:
    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_code_freeze.yml@vX.Y.Z
    with:
      library-name: NeMo-Export-Deploy
      python-package: nemo_export_deploy_common
      release-type: ${{ inputs.release-type }}
      next-pre-release: ""   # was forced to rc0 before
      next-dev: ""           # repo has no DEV field
```

Resulting next-version composition:

| `next-pre-release` | `next-dev` | version |
|--------------------|------------|---------|
| `rc0` (default)    | `dev0` (default) | `0.7.0rc0.dev0` |
| `""`               | `""`       | `0.7.0` |
| `rc0`              | `""`       | `0.7.0rc0` |
| `""`               | `dev0`     | `0.7.0.dev0` |

## Tested

- Validated the four tag combinations above against the new shell composition logic — all produce correct PEP 440 strings; legacy default is unchanged.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/_code_freeze.yml'))"` → valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>
