### PR TITLE
fix: catch direct URL dependencies in validate-wheel before publish

### DIFF
--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -360,11 +360,67 @@ jobs:
 
       - name: Install validators
         run: |
-          python3 -m pip install --upgrade twine==6.0.1 check-wheel-contents check-manifest
+          python3 -m pip install --upgrade twine==6.0.1 check-wheel-contents check-manifest packaging pkginfo
 
       - name: twine check
         run: |
           python3 -m twine check dist/*
+
+      - name: Check for direct URL dependencies
+        run: |
+          python3 - <<'PY'
+          """Fail if any built distribution declares a PEP 508 direct URL dependency.
+
+          PyPI rejects uploads whose metadata carries a ``Requires-Dist`` direct
+          reference (e.g. ``pkg @ git+https://...``). ``twine check`` does not catch
+          these, so the failure otherwise only surfaces at ``twine upload`` time.
+          """
+
+          import glob
+          import sys
+
+          from packaging.requirements import InvalidRequirement, Requirement
+          from pkginfo import SDist, Wheel
+
+
+          def direct_url_requirements(dist_path):
+              """Return the direct URL requirement strings declared by a distribution.
+
+              Args:
+                  dist_path: Path to a built wheel (``.whl``) or sdist (``.tar.gz``).
+
+              Returns:
+                  The ``Requires-Dist`` specifiers that carry a PEP 508 direct URL.
+              """
+              metadata = Wheel(dist_path) if dist_path.endswith(".whl") else SDist(dist_path)
+              offenders = []
+              for spec in metadata.requires_dist or []:
+                  try:
+                      requirement = Requirement(spec)
+                  except InvalidRequirement:
+                      continue
+                  if requirement.url:
+                      offenders.append(spec)
+              return offenders
+
+
+          def main():
+              """Scan ``dist/`` and exit non-zero if any direct URL dependency is found."""
+              distributions = sorted(glob.glob("dist/*.whl") + glob.glob("dist/*.tar.gz"))
+              found = False
+              for dist_path in distributions:
+                  for spec in direct_url_requirements(dist_path):
+                      found = True
+                      print(f"::error file={dist_path}::PyPI rejects direct URL dependencies: {spec}")
+              if found:
+                  print("Direct URL dependencies are not allowed on PyPI; replace them with a published release.")
+                  sys.exit(1)
+              print("No direct URL dependencies found.")
+
+
+          if __name__ == "__main__":
+              main()
+          PY
 
       - name: check-wheel-contents
         run: |


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

Evaluator release run [26895132713](https://github.com/NVIDIA-NeMo/Evaluator/actions/runs/26895132713) failed in `publish-wheel` but passed `validate-wheel`. The wheel declared a PEP 508 **direct URL dependency**:

```
nemo-skills @ git+https://github.com/NVIDIA-NeMo/Skills.git ; extra == "skills"
```

PyPI forbids direct URL dependencies and rejects the upload server-side:

```
400 Can't have direct dependency: nemo-skills @ git+https://github.com/NVIDIA-NeMo/Skills.git ; extra == "skills"
```

`twine check` only validates README/long-description rendering — it does **not** inspect `Requires-Dist`, so the problem slipped through validation and only blew up at `twine upload`, after the build/test/validate stages had all gone green.

## What changed

- **`_build_test_publish_wheel.yml`** → new `Check for direct URL dependencies` step in the `validate-wheel` job that fails fast, before `publish-wheel` ever runs.

## Details

- Parses `Requires-Dist` metadata of **both** the wheel and the sdist via `pkginfo`, and flags any specifier where `packaging.requirements.Requirement(...).url` is set (the exact PEP 508 direct-reference condition PyPI rejects).
- Emits a `::error file=...::` annotation per offending distribution naming the bad specifier, then exits non-zero.
- Adds `packaging` + `pkginfo` to the `Install validators` step (both are already transitive deps of `twine`; pinned explicitly so the step doesn't rely on transitive resolution).
- No new inputs — the check is unconditional, matching PyPI's own rule. Reusable-workflow consumers only pick it up when they bump their pinned tag, so the fleet isn't disrupted on merge.

## Flow

```mermaid
flowchart TD
    build[build-wheel] --> validate[validate-wheel]
    build --> test[test-wheel]
    validate --> tc[twine check<br/>README rendering only]
    tc --> nu[<b>NEW</b>: Check for direct URL dependencies<br/>parse Requires-Dist of whl + sdist]
    nu -->|direct URL dep found| failfast[Fail validate-wheel before publish]
    nu -->|clean| cwc[check-wheel-contents]
    cwc --> cm[check-manifest]
    validate --> publish[publish-wheel<br/>twine upload]
    test --> publish
    publish -.->|previously: only place<br/>the 400 surfaced| pypi[PyPI 400]

    style nu fill:#1f6f3c,color:#fff
    style failfast fill:#7a1f1f,color:#fff
    style pypi fill:#7a1f1f,color:#fff
```

## Tested

Built throwaway wheel + sdist fixtures and ran the **exact** step extracted from the parsed YAML (`bash -e -u -o pipefail`):

| Fixture | `Requires-Dist` | Result |
|---|---|---|
| direct URL dep (under an extra) | `nemo-skills @ git+https://...` | exit 1, `::error` on **both** whl + tar.gz |
| normal deps + markers | `requests>=2`, `pandas>=1 ; python_version >= '3.9'` | exit 0 |
| no dependencies (`requires_dist` is `None`) | — | exit 0, no crash |

Also confirmed `twine check` on the direct-dep fixture **PASSES** (reproducing the gap this PR closes), the workflow YAML parses cleanly, and `actionlint` reports nothing on the new step.

</details>
