### PR TITLE
fix: Add GITHUB_TOKEN to all community bot steps

### DIFF
--- a/.github/workflows/_community_bot.yml
+++ b/.github/workflows/_community_bot.yml
@@ -105,6 +105,8 @@ jobs:
           echo "username=$USERNAME" | tee -a $GITHUB_OUTPUT
 
       - name: Add community-request label for community users
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         if: |
           (
             steps.pre-flight.outputs.is_maintainer == 'false'
@@ -152,6 +154,8 @@ jobs:
           fi
 
       - name: Remove community-request label for maintainers
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         if: |
           (
             steps.pre-flight.outputs.is_maintainer == 'true'


### PR DESCRIPTION
fix: Add GITHUB_TOKEN to all community bot steps

I missed that the token needed to be added to these fields as well.