### PR TITLE
ci: use NVIDIA inference for Claude review

### DIFF
--- a/.github/workflows/_claude_review.yml
+++ b/.github/workflows/_claude_review.yml
@@ -10,14 +10,16 @@ on:
       model:
         description: 'Claude model to use'
         required: false
-        default: 'claude-opus-4-6'
+        default: 'aws/anthropic/bedrock-claude-opus-4-8'
         type: string
       prompt:
         description: 'Review prompt for Claude'
         required: true
         type: string
     secrets:
-      ANTHROPIC_API_KEY:
+      NVIDIA_INFERENCE_URL:
+        required: true
+      NVIDIA_INFERENCE_KEY:
         required: true
 
 jobs:
@@ -57,8 +59,12 @@ jobs:
 
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           trigger_phrase: ${{ inputs.trigger_phrase }}
           show_full_output: true
           claude_args: |


### PR DESCRIPTION
## Summary
- switch `_claude_review.yml` from `secrets.ANTHROPIC_API_KEY` to `secrets.NVIDIA_INFERENCE_KEY`
- set `ANTHROPIC_BASE_URL` from `secrets.NVIDIA_INFERENCE_URL`
- disable experimental betas and prompt caching for the NVIDIA inference endpoint
- update the default Claude model to `aws/anthropic/bedrock-claude-opus-4-8`

## Validation
- Parsed `.github/workflows/_claude_review.yml` with Ruby YAML loader
- Confirmed no remaining `ANTHROPIC_API_KEY` or `claude-opus-4-6` references in `_claude_review.yml`

Linear: AUT-644