### PR TITLE
fix: remove hardcoded uv 0.7.2 pin in build-wheel step

### DIFF
--- a/.github/workflows/_build_test_publish_wheel.yml
+++ b/.github/workflows/_build_test_publish_wheel.yml
@@ -186,7 +186,7 @@ jobs:
           # Install the package to import and check the version in a later step
           if [[ "$PACKAGING" == "uv" ]]; then
             # Install uv
-            curl -LsSf https://astral.sh/uv/0.7.2/install.sh | sh
+            curl -LsSf https://astral.sh/uv/install.sh | sh
             export PATH="$HOME/.local/bin:$PATH"
             uv venv --system-site-packages .venv
             source .venv/bin/activate


### PR DESCRIPTION
## Summary

- The build step in `_build_test_publish_wheel.yml` pinned uv to `0.7.2` while the test/publish step (line 303) already uses the unversioned `uv/install.sh`
- Aligns both to use the latest uv installer, removing stale-version warnings and potential resolver regressions seen by downstream callers (e.g. NVIDIA-NeMo/Gym)
