### PR TITLE
fix: add read-only exploration tools to claude review allowedTools

### DIFF
--- a/.github/workflows/_claude_review.yml
+++ b/.github/workflows/_claude_review.yml
@@ -68,7 +68,7 @@ jobs:
           trigger_phrase: ${{ inputs.trigger_phrase }}
           show_full_output: true
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Read,Bash(grep:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git ls-files:*)"
             --model "${{ inputs.model }}"
           prompt: |
             REPO: ${{ env.REPO }}


### PR DESCRIPTION
## Summary

- Claude's `_claude_review.yml` only allowed `gh pr *` commands, so any deeper code investigation (grep, file reads, git introspection) triggered permission denials mid-session
- Claude silently exits without posting a review when denied on a final Bash command — the workflow reports `success` but nothing appears on the PR
- Adds strictly read-only tools: `Read`, `Bash(grep:*)`, and scoped read-only git subcommands (`git diff`, `git log`, `git show`, `git ls-files`)

## What's added

| Tool | Purpose | Write risk |
|------|---------|------------|
| `Read` | Read files by path (Claude Code built-in) | None |
| `Bash(grep:*)` | Search file contents | None |
| `Bash(git diff:*)` | Compare code / history diffs | None |
| `Bash(git log:*)` | Read commit history | None |
| `Bash(git show:*)` | Read git objects | None |
| `Bash(git ls-files:*)` | List tracked files | None |

Notably **not** added: `find` (supports `-exec`), `sed` (supports `-i`), broad `gh` access, any write or network tools.

## Test plan

- [ ] Trigger `/claude review` on a PR with non-trivial code changes and confirm a review is posted
- [ ] Confirm existing small PRs (docs-only etc.) still work as before