### PR TITLE
fix: accept SPDX copyright headers

### DIFF
--- a/.github/actions/copyright-checker/check_copyright.py
+++ b/.github/actions/copyright-checker/check_copyright.py
@@ -9,9 +9,9 @@ import re  # Import the regular expression module
 from pathlib import Path
 from datetime import datetime
 
-# Regex to check for in the first line
-# Matches "Copyright.*NVIDIA CORPORATION.*All rights reserved."
-HEADER_REGEX = re.compile(r"^#\s*Copyright")
+# Regex to check for in leading comment lines.
+# Supports both legacy NVIDIA copyright headers and SPDX FileCopyrightText.
+HEADER_REGEX = re.compile(r"^#\s*(?:Copyright|SPDX-FileCopyrightText:\s*Copyright)")
 
 # Original format string, still used for the error message suggestion
 EXPECTED_HEADER = """# Copyright (c) {} NVIDIA CORPORATION & AFFILIATES. All rights reserved."""


### PR DESCRIPTION
## Summary
- Accept SPDX FileCopyrightText copyright headers in the copyright checker
- Keep the existing legacy # Copyright header format valid

## Validation
- python3 -m py_compile .github/actions/copyright-checker/check_copyright.py
- Fixture check confirmed legacy header passes, SPDX header passes, and missing header still fails