### PR TITLE
fix: checkout matching copyright checker ref

### DIFF
--- a/.github/workflows/_copyright_check.yml
+++ b/.github/workflows/_copyright_check.yml
@@ -64,12 +64,18 @@ jobs:
           files: '**/*.py'
           separator: ' '
 
+      - name: Determine copyright checker ref
+        id: copyright-checker-ref
+        run: |
+          WORKFLOW_REF="${{ github.workflow_ref }}"
+          echo "ref=${WORKFLOW_REF##*@}" | tee -a "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v6
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.66.7
+          ref: ${{ steps.copyright-checker-ref.outputs.ref }}
           path: copyright-checker
 
       - name: Check copyright headers


### PR DESCRIPTION
## Summary
- Remove the hardcoded copyright-checker checkout ref `v0.66.7`
- Derive the checker checkout ref from `github.workflow_ref` so the reusable workflow uses the same FW-CI-templates ref that invoked it

## Why
The labs-molt failure at https://github.com/NVIDIA-NeMo/labs-molt/actions/runs/28976691934/job/85986330757 used `_copyright_check.yml@v1.7.2`, but the workflow checked out FW-CI-templates at `v0.66.7`, so it never picked up the SPDX header support merged in the original PR.

## Validation
- Confirmed the failing labs-molt files have SPDX headers
- Verified ref parsing with `NVIDIA-NeMo/FW-CI-templates/.github/workflows/_copyright_check.yml@refs/tags/v1.7.2` -> `refs/tags/v1.7.2`