### PR TITLE
fix: checkout reusable workflow source for copyright checker

### DIFF
--- a/.github/workflows/_copyright_check.yml
+++ b/.github/workflows/_copyright_check.yml
@@ -64,18 +64,12 @@ jobs:
           files: '**/*.py'
           separator: ' '
 
-      - name: Determine copyright checker ref
-        id: copyright-checker-ref
-        run: |
-          WORKFLOW_REF="${{ github.workflow_ref }}"
-          echo "ref=${WORKFLOW_REF##*@}" | tee -a "$GITHUB_OUTPUT"
-
       - name: Checkout
         uses: actions/checkout@v6
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
-          repository: NVIDIA-NeMo/FW-CI-templates
-          ref: ${{ steps.copyright-checker-ref.outputs.ref }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: copyright-checker
 
       - name: Check copyright headers


### PR DESCRIPTION
## Summary
- Use `job.workflow_repository` when checking out the copyright checker source
- Use `job.workflow_sha` so the checker comes from the exact reusable workflow revision that is running
- Remove the incorrect `github.workflow_ref` parsing step

## Why
The labs-molt run at https://github.com/NVIDIA-NeMo/labs-molt/actions/runs/28978959566/job/85992909027 showed that `github.workflow_ref` resolves to the caller workflow (`NVIDIA-NeMo/labs-molt/.github/workflows/copyright-check.yml@refs/heads/pull-request/2`) inside this reusable workflow. That made the checkout try to fetch `NVIDIA-NeMo/FW-CI-templates@refs/heads/pull-request/2`, which does not exist.

GitHub documents `job.workflow_repository` and `job.workflow_sha` as the reusable workflow identity fields for checking out files co-located with the reusable workflow.

## Validation
- Confirmed the failing log tried to fetch `refs/heads/pull-request/2` from FW-CI-templates
- Checked GitHub context docs for reusable workflow source checkout fields
- Diff is limited to `.github/workflows/_copyright_check.yml`