### PR TITLE
fix: handle local copyright base refs

### DIFF
--- a/.github/workflows/_copyright_check.yml
+++ b/.github/workflows/_copyright_check.yml
@@ -44,16 +44,22 @@ jobs:
       - name: Determine base reference
         id: get-sha
         run: |
+          IS_PR=${{ startsWith(github.ref, 'refs/heads/pull-request/') }}
           BASE_REF=${{ (startsWith(github.ref, 'refs/heads/pull-request/') && fromJSON(steps.get-pr-info.outputs.pr-info).base.ref) || 'HEAD~1' }}
 
           git config --global user.email "you@example.com"
           git config --global user.name "GitHub Action"
 
-          git fetch origin $BASE_REF
-          git merge origin/$BASE_REF
+          if [[ "$IS_PR" == "true" ]]; then
+            git fetch origin "$BASE_REF"
+            git merge "origin/$BASE_REF"
+            BASE_SHA=$(git rev-parse "origin/$BASE_REF")
+          else
+            BASE_SHA=$(git rev-parse "$BASE_REF")
+          fi
 
-          echo "sha=$(git rev-parse HEAD)" | tee -a $GITHUB_OUTPUT
-          echo "base_sha=${BASE_REF}" | tee -a $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
+          echo "base_sha=${BASE_SHA}" | tee -a "$GITHUB_OUTPUT"
 
       - name: Get changed files
         id: changed-files


### PR DESCRIPTION
## Summary
- avoid fetching local revision expressions like `HEAD~1` in the copyright workflow
- resolve the non-PR fallback base locally and pass the concrete SHA to `changed-files`
- keep PR branch base handling via `origin/<base-ref>`

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_copyright_check.yml"); puts "yaml ok"'`
- `bash -euxo pipefail -c 'IS_PR=false; BASE_REF=HEAD~1; if [[ "$IS_PR" == "true" ]]; then git fetch origin "$BASE_REF"; git merge "origin/$BASE_REF"; BASE_SHA=$(git rev-parse "origin/$BASE_REF"); else BASE_SHA=$(git rev-parse "$BASE_REF"); fi; git rev-parse HEAD; printf "base_sha=%s\n" "$BASE_SHA"'`
- `git diff --check -- .github/workflows/_copyright_check.yml`