### PR TITLE
fix: allow Claude review top-level PR comments

### DIFF
--- a/.github/workflows/_claude_review.yml
+++ b/.github/workflows/_claude_review.yml
@@ -180,7 +180,7 @@ jobs:
           show_full_output: false
           claude_args: |
             --add-dir "${{ env.PR_HEAD_DIR }}"
-            --allowedTools "Read,Glob,Grep,Bash(./review-context/check-pr-revision.sh),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"
+            --allowedTools "Read,Glob,Grep,Bash(./review-context/check-pr-revision.sh),Bash(gh pr comment:*),mcp__github_comment__update_claude_comment,mcp__github_inline_comment__create_inline_comment"
             --model "${{ inputs.model }}"
           prompt: |
             REPO: ${{ env.REPO }}


### PR DESCRIPTION
## Summary
- Allow the reusable Claude review workflow to run `gh pr comment` for top-level PR summaries
- Keep the existing revision-check and MCP inline/top-level comment tools available

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/_claude_review.yml")'`