### PR TITLE
chore: Move Fern inputs to secrets

### DIFF
--- a/.github/workflows/_fern_docs_preview_build.yml
+++ b/.github/workflows/_fern_docs_preview_build.yml
@@ -49,9 +49,9 @@
 #            actions: read
 #            id-token: write
 #            pull-requests: write
-#          with:
-#            aws-role-to-assume: arn:aws:iam::<account-id>:role/<role-name>
-#            fern-secret-id: docs/fern/github/<owner>/<repo>/token
+#          secrets:
+#            DOCS_FERN_AWS_ROLE_TO_ASSUME: ${{ secrets.DOCS_FERN_AWS_ROLE_TO_ASSUME }}
+#            DOCS_FERN_SECRET_ID: ${{ secrets.DOCS_FERN_SECRET_ID }}
 #
 #    fern-docs-preview-close.yml   (close half — cleanup pair, no secrets)
 #      on:
@@ -72,9 +72,9 @@
 #          permissions:
 #            actions: read
 #            id-token: write
-#          with:
-#            aws-role-to-assume: arn:aws:iam::<account-id>:role/<role-name>
-#            fern-secret-id: docs/fern/github/<owner>/<repo>/token
+#          secrets:
+#            DOCS_FERN_AWS_ROLE_TO_ASSUME: ${{ secrets.DOCS_FERN_AWS_ROLE_TO_ASSUME }}
+#            DOCS_FERN_SECRET_ID: ${{ secrets.DOCS_FERN_SECRET_ID }}
 #
 # 2. If you override `artifact-name` here, pass the same value to the comment
 #    workflow. The default (`fern-preview`) works when there is only one Fern

--- a/.github/workflows/_fern_docs_preview_cleanup.yml
+++ b/.github/workflows/_fern_docs_preview_cleanup.yml
@@ -41,9 +41,9 @@
 #         permissions:
 #           actions: read
 #           id-token: write
-#         with:
-#           aws-role-to-assume: arn:aws:iam::<account-id>:role/<role-name>
-#           fern-secret-id: docs/fern/github/<owner>/<repo>/token
+#         secrets:
+#           DOCS_FERN_AWS_ROLE_TO_ASSUME: ${{ secrets.DOCS_FERN_AWS_ROLE_TO_ASSUME }}
+#           DOCS_FERN_SECRET_ID: ${{ secrets.DOCS_FERN_SECRET_ID }}
 #
 # Required configuration:
 # - GitHub OIDC trust for the caller and this pinned reusable workflow.
@@ -54,19 +54,11 @@ name: "Preview Fern Docs: Cleanup"
 on:
   workflow_call:
     inputs:
-      aws-role-to-assume:
-        description: AWS IAM role ARN used to read the Fern token
-        required: true
-        type: string
       aws-region:
         description: AWS region containing the Fern token secret
         required: false
         type: string
         default: us-east-2
-      fern-secret-id:
-        description: AWS Secrets Manager name or ARN containing the Fern token
-        required: true
-        type: string
       artifact-name:
         description: Artifact name uploaded by the close workflow
         required: false
@@ -81,6 +73,13 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      DOCS_FERN_AWS_ROLE_TO_ASSUME:
+        description: AWS IAM role ARN used to read the Fern token
+        required: true
+      DOCS_FERN_SECRET_ID:
+        description: AWS Secrets Manager name or ARN containing the Fern token
+        required: true
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -121,15 +120,16 @@ jobs:
         if: steps.preview.outputs.preview_url != ''
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
-          role-to-assume: ${{ inputs.aws-role-to-assume }}
+          role-to-assume: ${{ secrets.DOCS_FERN_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws-region }}
+          mask-aws-account-id: true
 
       - name: Read Fern token
         if: steps.preview.outputs.preview_url != ''
         uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
-            FERN_TOKEN,${{ inputs.fern-secret-id }}
+            FERN_TOKEN,${{ secrets.DOCS_FERN_SECRET_ID }}
 
       - name: Delete preview deployment
         if: steps.preview.outputs.preview_url != ''

--- a/.github/workflows/_fern_docs_preview_comment.yml
+++ b/.github/workflows/_fern_docs_preview_comment.yml
@@ -31,19 +31,11 @@ name: "Preview Fern Docs: Comment"
 on:
   workflow_call:
     inputs:
-      aws-role-to-assume:
-        description: AWS IAM role ARN used to read the Fern token
-        required: true
-        type: string
       aws-region:
         description: AWS region containing the Fern token secret
         required: false
         type: string
         default: us-east-2
-      fern-secret-id:
-        description: AWS Secrets Manager name or ARN containing the Fern token
-        required: true
-        type: string
       artifact-name:
         description: Name of the artifact uploaded by the build workflow
         required: false
@@ -58,6 +50,13 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      DOCS_FERN_AWS_ROLE_TO_ASSUME:
+        description: AWS IAM role ARN used to read the Fern token
+        required: true
+      DOCS_FERN_SECRET_ID:
+        description: AWS Secrets Manager name or ARN containing the Fern token
+        required: true
 jobs:
   preview:
     runs-on: ubuntu-latest
@@ -103,14 +102,15 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
-          role-to-assume: ${{ inputs.aws-role-to-assume }}
+          role-to-assume: ${{ secrets.DOCS_FERN_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws-region }}
+          mask-aws-account-id: true
 
       - name: Read Fern token
         uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
-            FERN_TOKEN,${{ inputs.fern-secret-id }}
+            FERN_TOKEN,${{ secrets.DOCS_FERN_SECRET_ID }}
 
       - name: Generate library reference MDX (autodocs)
         if: steps.libraries.outputs.present == 'true'

--- a/.github/workflows/_fern_docs_publish.yml
+++ b/.github/workflows/_fern_docs_publish.yml
@@ -28,19 +28,11 @@ name: Publish Fern Docs
 on:
   workflow_call:
     inputs:
-      aws-role-to-assume:
-        description: AWS IAM role ARN used to read the Fern token
-        required: true
-        type: string
       aws-region:
         description: AWS region containing the Fern token secret
         required: false
         type: string
         default: us-east-2
-      fern-secret-id:
-        description: AWS Secrets Manager name or ARN containing the Fern token
-        required: true
-        type: string
       fern-directory:
         description: Path to the fern directory relative to the repository root
         required: false
@@ -55,6 +47,13 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      DOCS_FERN_AWS_ROLE_TO_ASSUME:
+        description: AWS IAM role ARN used to read the Fern token
+        required: true
+      DOCS_FERN_SECRET_ID:
+        description: AWS Secrets Manager name or ARN containing the Fern token
+        required: true
 permissions:
   contents: read
   id-token: write
@@ -90,14 +89,15 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5
         with:
-          role-to-assume: ${{ inputs.aws-role-to-assume }}
+          role-to-assume: ${{ secrets.DOCS_FERN_AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws-region }}
+          mask-aws-account-id: true
 
       - name: Read Fern token
         uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2
         with:
           secret-ids: |
-            FERN_TOKEN,${{ inputs.fern-secret-id }}
+            FERN_TOKEN,${{ secrets.DOCS_FERN_SECRET_ID }}
 
       - name: Generate library reference MDX (autodocs)
         if: steps.libraries.outputs.present == 'true'


### PR DESCRIPTION
AWS doesn't consider the account ID or role names as secrets, but I'm moving them to secrets so no one gets edgy about it.

PLMK what I can clarify and thanks!