### PR TITLE
fix: provide default exempt-pr-labels on scheduled stale runs

### DIFF
--- a/.github/workflows/_close_inactive_issue_pr.yml
+++ b/.github/workflows/_close_inactive_issue_pr.yml
@@ -30,4 +30,4 @@ jobs:
           stale-pr-message: "This PR is stale because it has been open for 14 days with no activity. Remove stale label or comment or update or this will be closed in 7 days."
           close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          exempt-pr-labels: ${{ inputs.exempt-pr-labels }}
+          exempt-pr-labels: ${{ inputs.exempt-pr-labels || 'community-request' }}


### PR DESCRIPTION
## Bug

`_close_inactive_issue_pr.yml` runs on both `workflow_call` and `schedule`. On `schedule`, the `inputs` context is empty, so `${{ inputs.exempt-pr-labels }}` evaluated to an empty string instead of the intended default `community-request`. This meant scheduled stale runs did not exempt community-request PRs.

## Fix

Add an explicit fallback: `${{ inputs.exempt-pr-labels || \`community-request\` }}`.

## Verification

YAML syntax validated with `python -c "import yaml; yaml.safe_load(...)`.