### PR TITLE
fix: tolerate trailing whitespace in /claude review trigger phrase

### DIFF
--- a/.github/workflows/_claude_review.yml
+++ b/.github/workflows/_claude_review.yml
@@ -28,7 +28,7 @@ jobs:
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      github.event.comment.body == inputs.trigger_phrase
+      startsWith(github.event.comment.body, inputs.trigger_phrase)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- The `authorize` job used `==` for an exact match on the comment body, causing `/claude review ` (with trailing space) to be silently skipped
- Changed to `startsWith(github.event.comment.body, inputs.trigger_phrase)` so trailing whitespace (common from editors/mobile) doesn't block the review