### PR TITLE
fix: preserve community bot membership checks

### DIFF
--- a/.github/workflows/_community_bot.yml
+++ b/.github/workflows/_community_bot.yml
@@ -135,7 +135,8 @@ jobs:
 
       - name: Add community-request label for community users
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || github.token }}
+          # The configured NVIDIA App can label pull requests but not regular issues.
+          GITHUB_TOKEN: ${{ github.event.issue.pull_request && steps.app-token.outputs.token || secrets.GH_TOKEN || steps.app-token.outputs.token || github.token }}
         if: |
           (
             steps.pre-flight.outputs.is_maintainer == 'false'
@@ -147,7 +148,9 @@ jobs:
 
       - name: Add community issue to community project
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || github.token }}
+          # The project lives in NVIDIA-NeMo even when the caller repository lives in NVIDIA.
+          # Prefer the PAT so this cross-organization mutation retains the pre-v1.5.0 behavior.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || steps.app-token.outputs.token || github.token }}
         if: |
           (
             steps.pre-flight.outputs.is_maintainer == 'false'
@@ -186,7 +189,7 @@ jobs:
 
       - name: Remove community-request label for maintainers
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || github.token }}
+          GITHUB_TOKEN: ${{ github.event.issue.pull_request && steps.app-token.outputs.token || secrets.GH_TOKEN || steps.app-token.outputs.token || github.token }}
         if: |
           (
             steps.pre-flight.outputs.is_maintainer == 'true'

--- a/.github/workflows/_community_bot.yml
+++ b/.github/workflows/_community_bot.yml
@@ -21,12 +21,16 @@ on:
         description: The issue author to test with
         type: string
       app-id:
-        required: true
+        required: false
         description: The GitHub App ID to use for the bot token
         type: string
+        default: ""
     secrets:
       BOT_KEY:
-        required: true
+        required: false
+      GH_TOKEN:
+        description: Optional PAT used for membership checks and as a legacy bot-token fallback
+        required: false
 
 jobs:
   manage-community-label:
@@ -40,8 +44,11 @@ jobs:
     env:
       ISSUE_NUMBER: ${{ github.event_name == 'push' && inputs.issue_number || github.event.issue.number }}
       COMMUNITY_PROJECT_ID: ${{ inputs.community_project_id }}
+      REPO: ${{ github.repository }}
     steps:
-      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+      - name: Create GitHub App token
+        if: inputs.app-id != ''
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: app-token
         with:
           app-id: ${{ inputs.app-id }}
@@ -50,15 +57,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || github.token }}
 
       - name: Check pre-conditions
         id: pre-flight
         env:
+          AUTHOR_ASSOCIATION: ${{ github.event.issue.author_association }}
           IS_VALID_EVENT: ${{ github.event_name == 'issues' || github.event_name == 'issue_comment' }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          # Prefer the PAT for private/cross-organization membership visibility. Callers that do
+          # not have one retain the App-token behavior introduced in v1.5.0.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN || steps.app-token.outputs.token || github.token }}
           ISSUE_AUTHOR: ${{ github.event_name == 'push' && inputs.issue_author || github.event.issue.user.login }}
-          REPO: ${{ github.repository }}
         run: |
           # Get the username who triggered the action
           USERNAME="${{ github.actor }}"
@@ -66,49 +75,67 @@ jobs:
           # For manual testing, always treat as community user
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "Manual test mode - treating as community user"
-            echo "is_maintainer=false" | tee -a $GITHUB_OUTPUT
-            echo "is_valid_event=true" | tee -a $GITHUB_OUTPUT
-            echo "username=$USERNAME" | tee -a $GITHUB_OUTPUT
+            echo "is_maintainer=false" | tee -a "$GITHUB_OUTPUT"
+            echo "is_valid_event=true" | tee -a "$GITHUB_OUTPUT"
+            echo "username=$USERNAME" | tee -a "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Checking if $ISSUE_AUTHOR is a repo collaborator..."
-          API_URL="https://api.github.com/repos/$REPO/collaborators/$ISSUE_AUTHOR"
-          REPO_MEMBERSHIP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            $API_URL)
+          case "$AUTHOR_ASSOCIATION" in
+            OWNER|MEMBER|COLLABORATOR)
+              IS_ASSOCIATED=true
+              ;;
+            *)
+              IS_ASSOCIATED=false
+              ;;
+          esac
 
-          echo "Checking if $ISSUE_AUTHOR is an org collaborator to NVIDIA-NeMo..."
-          API_URL="https://api.github.com/orgs/NVIDIA-NeMo/members/$ISSUE_AUTHOR"
-          ORG_NVIDIA_NEMO_MEMBERSHIP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            $API_URL)
-
-          echo "Checking if $ISSUE_AUTHOR is an org collaborator to NVIDIA..."
-          API_URL="https://api.github.com/orgs/NVIDIA/members/$ISSUE_AUTHOR"
-          ORG_NVIDIA_MEMBERSHIP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -L \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            $API_URL)
-
-          if [ "$ISSUE_AUTHOR" = "svcnemo-autobot" ] || [ "$REPO_MEMBERSHIP_RESPONSE" -eq 204 ] || [ "$ORG_NVIDIA_NEMO_MEMBERSHIP_RESPONSE" -eq 204 ] || [ "$ORG_NVIDIA_MEMBERSHIP_RESPONSE" -eq 204 ]; then
-            echo "is_maintainer=true" | tee -a $GITHUB_OUTPUT
+          if [[ "$ISSUE_AUTHOR" = "svcnemo-autobot" || "$IS_ASSOCIATED" = "true" ]]; then
+            IS_MAINTAINER=true
           else
-            echo "is_maintainer=false" | tee -a $GITHUB_OUTPUT
+            echo "Checking if $ISSUE_AUTHOR is a repo collaborator..."
+            API_URL="https://api.github.com/repos/$REPO/collaborators/$ISSUE_AUTHOR"
+            REPO_MEMBERSHIP_RESPONSE=$(curl --silent --show-error --output /dev/null \
+              --write-out "%{http_code}" --location \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$API_URL")
+
+            echo "Checking if $ISSUE_AUTHOR is an organization member of NVIDIA-NeMo..."
+            API_URL="https://api.github.com/orgs/NVIDIA-NeMo/members/$ISSUE_AUTHOR"
+            ORG_NVIDIA_NEMO_MEMBERSHIP_RESPONSE=$(curl --silent --show-error \
+              --output /dev/null --write-out "%{http_code}" --location \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$API_URL")
+
+            echo "Checking if $ISSUE_AUTHOR is an organization member of NVIDIA..."
+            API_URL="https://api.github.com/orgs/NVIDIA/members/$ISSUE_AUTHOR"
+            ORG_NVIDIA_MEMBERSHIP_RESPONSE=$(curl --silent --show-error --output /dev/null \
+              --write-out "%{http_code}" --location \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$API_URL")
+
+            if [[ "$REPO_MEMBERSHIP_RESPONSE" -eq 204 \
+              || "$ORG_NVIDIA_NEMO_MEMBERSHIP_RESPONSE" -eq 204 \
+              || "$ORG_NVIDIA_MEMBERSHIP_RESPONSE" -eq 204 ]]; then
+              IS_MAINTAINER=true
+            else
+              IS_MAINTAINER=false
+            fi
           fi
 
-          echo "is_valid_event=$IS_VALID_EVENT" | tee -a $GITHUB_OUTPUT
-
-          echo "username=$USERNAME" | tee -a $GITHUB_OUTPUT
+          echo "is_maintainer=$IS_MAINTAINER" | tee -a "$GITHUB_OUTPUT"
+          echo "is_valid_event=$IS_VALID_EVENT" | tee -a "$GITHUB_OUTPUT"
+          echo "username=$USERNAME" | tee -a "$GITHUB_OUTPUT"
 
       - name: Add community-request label for community users
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || github.token }}
         if: |
           (
             steps.pre-flight.outputs.is_maintainer == 'false'
@@ -116,18 +143,19 @@ jobs:
           )
         run: |
           # Add the community-request label
-          gh issue edit $ISSUE_NUMBER --add-label "community-request"
+          gh issue edit "$ISSUE_NUMBER" --add-label "community-request"
 
       - name: Add community issue to community project
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || github.token }}
         if: |
           (
             steps.pre-flight.outputs.is_maintainer == 'false'
             && steps.pre-flight.outputs.is_valid_event == 'true'
           )
         run: |
-          ISSUE_NODE_ID=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER --jq .node_id)
+          ISSUE_NODE_ID=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER" --jq .node_id)
+          # shellcheck disable=SC2016
           PROJECT_NODE_ID=$(gh api graphql -f query='
             query($projectNumber: Int!) {
               organization(login: "NVIDIA-NeMo") {
@@ -140,6 +168,7 @@ jobs:
           echo "Project ID: $PROJECT_NODE_ID"
           echo "Adding issue $ISSUE_NUMBER to project $COMMUNITY_PROJECT_ID"
 
+          # shellcheck disable=SC2016
           RESPONSE=$(gh api graphql -f query='
               mutation($project:ID!, $issue:ID!) {
                   addProjectV2ItemById(input: {projectId: $project, contentId: $issue}) {
@@ -149,15 +178,15 @@ jobs:
                   }
               }' -f project="$PROJECT_NODE_ID" -f issue="$ISSUE_NODE_ID")
 
-          echo $RESPONSE
+          echo "$RESPONSE"
 
-          if echo "$RESPONSE" | grep -q "error"; then
+          if grep -q "error" <<< "$RESPONSE"; then
             exit 1
           fi
 
       - name: Remove community-request label for maintainers
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token || secrets.GH_TOKEN || github.token }}
         if: |
           (
             steps.pre-flight.outputs.is_maintainer == 'true'

--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -10,4 +10,8 @@ jobs:
   community-bot:
     uses: ./.github/workflows/_community_bot.yml
     with:
-      maintainers: ko3n1g
+      community_project_id: ${{ vars.COMMUNITY_PROJECT_ID }}
+      app-id: ${{ vars.BOT_ID }}
+    secrets:
+      BOT_KEY: ${{ secrets.BOT_KEY }}
+      GH_TOKEN: ${{ secrets.PAT }}


### PR DESCRIPTION
## Background / motivation

The v1.5.0 community-bot migration replaced its PAT with a repository-scoped GitHub App token. The configured NVIDIA App does not cover every operation previously performed by the PAT:

- NVIDIA/Megatron-LM run `30962783269`: App token creation, checkout, preflight, and PR labeling succeeded; adding the item to the NVIDIA-NeMo community project failed.
- NVIDIA/Megatron-LM run `30988177259`: labeling a regular issue failed before the project step.
- Private and cross-organization membership lookups do not retain the PAT's previous visibility. The affected author in NVIDIA/Megatron-LM#6190 has `author_association=MEMBER`, so the event already carries a reliable maintainer signal.

NVIDIA/Megatron-LM reverted its v1.8.7 adoption in NVIDIA/Megatron-LM#6288. The repository-local caller also still passed the removed `maintainers` input; recent community-bot runs, including run `30837560092`, failed during workflow startup.

Closes #537.

## What changed

- Treat event associations `OWNER`, `MEMBER`, and `COLLABORATOR` as maintainers before making membership API calls.
- Make `app-id` and `BOT_KEY` optional and restore optional `GH_TOKEN` support for v0.65.10-era PAT callers.
- Use `GH_TOKEN` for membership reads, regular-issue label changes, and the cross-organization NVIDIA-NeMo project mutation when both credentials exist.
- Continue preferring the App token for checkout and PR label changes.
- Fall back to the caller's scoped `github.token` when neither explicit credential is configured.
- Update this repository's caller to the current `community_project_id` / `app-id` contract and pass its organization-managed App and PAT credentials.

## Details

| Operation | App only | PAT only | App + PAT |
| --- | --- | --- | --- |
| Membership reads | App | PAT | PAT |
| Checkout | App | PAT | App |
| PR label changes | App | PAT | App |
| Regular-issue label changes | App | PAT | PAT |
| NVIDIA-NeMo project mutation | App | PAT | PAT |

The table describes token selection. App-only callers still require their App installation to grant every permission needed by their repository and project topology.

Associated maintainers and `svcnemo-autobot` short-circuit before the API fallback. Unassociated authors retain the collaborator and NVIDIA organization checks.

## Tested

- `git diff --check origin/main...HEAD` — passed.
- `actionlint .github/workflows/_community_bot.yml .github/workflows/community-bot.yml` — passed with zero findings.
- `actionlint` with temporary PAT-only and App-only reusable-workflow callers — both contracts accepted with zero findings; the checked-in dual-auth caller also passed.
- Extracted the exact `pre-flight` shell with `yq` and ran a mocked HTTP-status matrix:
  - `MEMBER`, `OWNER`, `COLLABORATOR`, `svcnemo-autobot`, repo collaborator, NVIDIA-NeMo member, and NVIDIA member → `is_maintainer=true`.
  - Unaffiliated author with all membership responses `404` → `is_maintainer=false`.
- `gh run view 30962783269 --repo NVIDIA/Megatron-LM --json jobs` — PR label step succeeded; NVIDIA-NeMo project step failed.
- `gh run view 30988177259 --repo NVIDIA/Megatron-LM --json jobs` — regular-issue label step failed.
- `gh api repos/NVIDIA/Megatron-LM/issues/6190 --jq '[.user.login, .author_association]'` → `["wujingyue","MEMBER"]`.
