### PR TITLE
fix: avoid duplicate community follow-up labels

### DIFF
--- a/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
+++ b/.github/actions/identify-follow-up-issues/identify_follow_up_issues.py
@@ -45,6 +45,8 @@ WAITING_ON_CUSTOMER_LABEL = "waiting-on-customer"
 WAITING_ON_CUSTOMER_COLOR = "c2e0c6"
 WAITING_ON_CUSTOMER_DESCRIPTION = "Waiting on the original author to respond"
 
+APPROVED_LABEL = "Approved"
+
 SKIPPED_REPOS = {"Megatron-Bridge"}
 
 CLASSIFICATION_SYSTEM_PROMPT = """\
@@ -258,11 +260,67 @@ def _is_excluded(item: dict) -> bool:
     )
 
 
+def _get_waiting_linked_pr_urls(content: dict) -> list[str]:
+    """Return open linked PR URLs carrying the waiting-on-maintainers label."""
+    linked_prs = content.get("closedByPullRequestsReferences", {}).get("nodes", [])
+    waiting_pr_urls: list[str] = []
+
+    for pull_request in linked_prs:
+        if pull_request.get("state") != "OPEN":
+            continue
+
+        labels = pull_request.get("labels", {}).get("nodes", [])
+        label_names = {label.get("name", "") for label in labels}
+        if WAITING_ON_MAINTAINERS_LABEL in label_names:
+            waiting_pr_urls.append(pull_request.get("url", ""))
+
+    return [url for url in waiting_pr_urls if url]
+
+
+def _determine_needs_attention(
+    *,
+    item_type: str,
+    repo_name: str,
+    classification: str,
+    last_comment_date: str,
+    last_approval_date: str = "",
+    all_reviewers_approved: bool = False,
+    has_approved_label: bool = False,
+    has_waiting_linked_pr: bool = False,
+    now: datetime | None = None,
+) -> tuple[bool, bool, bool]:
+    """Calculate follow-up state and report which staleness rules matched.
+
+    Returns (needs_attention, comment_is_stale, approved_unmerged_override).
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+
+    cutoff = now - timedelta(hours=48)
+    comment_dt = datetime.fromisoformat(last_comment_date.replace("Z", "+00:00"))
+    is_stale = comment_dt < cutoff
+    needs_attention = classification == "waiting-on-maintainers" and is_stale
+
+    approved_unmerged = False
+    if item_type == "PullRequest" and last_approval_date and all_reviewers_approved:
+        approval_dt = datetime.fromisoformat(last_approval_date.replace("Z", "+00:00"))
+        megatron_approval_gate_passed = repo_name != "Megatron-LM" or has_approved_label
+        approved_unmerged = approval_dt < cutoff and megatron_approval_gate_passed
+        if approved_unmerged:
+            needs_attention = True
+
+    if item_type == "Issue" and has_waiting_linked_pr:
+        needs_attention = False
+
+    return needs_attention, is_stale, approved_unmerged
+
+
 def update_labels(issues: list[dict], org: str, token: str):
     """Update labels on all issues based on LLM classification.
 
     - waiting-on-maintainers (needs_attention=True): add waiting-on-maintainers, remove waiting-on-customer
     - waiting-on-author (needs_attention=False): add waiting-on-customer, remove waiting-on-maintainers
+    - Issues with a linked PR waiting on maintainers: remove waiting-on-maintainers
     - Excluded items (Megatron-LM dev PRs, draft PRs): remove both labels
     - Migration: remove deprecated 'needs-follow-up' label wherever found
     """
@@ -372,6 +430,19 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
                   labels(first: 100) {
                     nodes {
                       name
+                    }
+                  }
+                  closedByPullRequestsReferences(first: 20, includeClosedPrs: false) {
+                    totalCount
+                    nodes {
+                      url
+                      state
+                      labels(first: 50) {
+                        totalCount
+                        nodes {
+                          name
+                        }
+                      }
                     }
                   }
                 }
@@ -485,6 +556,21 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
             has_maintainers_label = WAITING_ON_MAINTAINERS_LABEL in label_names
             has_waiting_on_customer_label = WAITING_ON_CUSTOMER_LABEL in label_names
             has_deprecated_label = DEPRECATED_NEEDS_FOLLOWUP_LABEL in label_names
+            has_approved_label = APPROVED_LABEL in label_names
+
+            waiting_linked_pr_urls = []
+            if item_type == "Issue":
+                waiting_linked_pr_urls = _get_waiting_linked_pr_urls(content)
+
+                linked_prs = content.get("closedByPullRequestsReferences", {})
+                linked_pr_nodes = linked_prs.get("nodes", [])
+                if linked_prs.get("totalCount", 0) > len(linked_pr_nodes):
+                    print(f"  Warning: linked PR results truncated for {repo_name}#{content.get('number')}")
+                for linked_pr in linked_pr_nodes:
+                    linked_labels = linked_pr.get("labels", {})
+                    if linked_labels.get("totalCount", 0) > len(linked_labels.get("nodes", [])):
+                        print(f"  Warning: linked PR labels truncated for {linked_pr.get('url', 'unknown PR')}")
+            has_waiting_linked_pr = bool(waiting_linked_pr_urls)
 
             # Only include open issues/PRs (also include closed items with labels to clean up)
             if content.get("state") != "OPEN" and not has_maintainers_label and not has_waiting_on_customer_label and not has_deprecated_label:
@@ -614,6 +700,9 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
                 "has_maintainers_label": has_maintainers_label,
                 "has_waiting_on_customer_label": has_waiting_on_customer_label,
                 "has_deprecated_label": has_deprecated_label,
+                "has_approved_label": has_approved_label,
+                "has_waiting_linked_pr": has_waiting_linked_pr,
+                "waiting_linked_pr_urls": waiting_linked_pr_urls,
                 "target_branch": target_branch,
                 "is_draft": is_draft,
                 "last_approval_date": last_approval_date,
@@ -626,24 +715,23 @@ def fetch_project_items(org: str, project_number: int, token: str, llm_client: o
                 classification = classify_with_llm(llm_client, llm_model, item_dict)
                 item_dict["classification"] = classification
 
-                # Only flag as needing attention if classified as waiting-on-maintainers
-                # AND the last comment is more than 48 hours old
-                comment_dt = datetime.fromisoformat(last_comment_date.replace("Z", "+00:00"))
-                is_stale = comment_dt < datetime.now(timezone.utc) - timedelta(hours=48)
-                item_dict["needs_attention"] = classification == "waiting-on-maintainers" and is_stale
+                item_dict["needs_attention"], is_stale, approved_unmerged = _determine_needs_attention(
+                    item_type=item_type,
+                    repo_name=repo_name,
+                    classification=classification,
+                    last_comment_date=last_comment_date,
+                    last_approval_date=last_approval_date,
+                    all_reviewers_approved=all_reviewers_approved,
+                    has_approved_label=has_approved_label,
+                    has_waiting_linked_pr=has_waiting_linked_pr,
+                )
 
-                # Approved PRs not merged after 48 hours need follow-up,
-                # but only if ALL reviewers' latest reviews are approvals.
-                # If any reviewer's latest state is not APPROVED (e.g.
-                # changes requested, commented, dismissed), defer to the
-                # LLM classification instead.
-                if item_type == "PullRequest" and last_approval_date and all_reviewers_approved:
-                    approval_dt = datetime.fromisoformat(last_approval_date.replace("Z", "+00:00"))
-                    approval_stale = approval_dt < datetime.now(timezone.utc) - timedelta(hours=48)
-                    if approval_stale:
-                        item_dict["needs_attention"] = True
-
-                print(f"  {item_dict['url']}: {classification} (stale={is_stale}, approved_unmerged={'48h+' if item_type == 'PullRequest' and last_approval_date and item_dict['needs_attention'] else 'n/a'})")
+                linked_pr_note = ", ".join(waiting_linked_pr_urls) if waiting_linked_pr_urls else "n/a"
+                print(
+                    f"  {item_dict['url']}: {classification} "
+                    f"(stale={is_stale}, approved_unmerged={'48h+' if approved_unmerged else 'n/a'}, "
+                    f"suppressed_by_linked_pr={linked_pr_note})"
+                )
 
             items_list.append(item_dict)
 
@@ -698,6 +786,9 @@ def write_debug_csv(items: list[dict], org: str, output_path: str):
         "has_waiting_on_customer_label",
         "waiting_on_customer_action",
         "has_deprecated_label",
+        "has_waiting_linked_pr",
+        "waiting_linked_pr_urls",
+        "suppression_reason",
     ]
 
     with open(output_path, "w", newline="") as f:
@@ -739,6 +830,9 @@ def write_debug_csv(items: list[dict], org: str, output_path: str):
                 "has_waiting_on_customer_label": item["has_waiting_on_customer_label"],
                 "waiting_on_customer_action": waiting_action,
                 "has_deprecated_label": item.get("has_deprecated_label", False),
+                "has_waiting_linked_pr": item.get("has_waiting_linked_pr", False),
+                "waiting_linked_pr_urls": ",".join(item.get("waiting_linked_pr_urls", [])),
+                "suppression_reason": "linked-pr-waiting-on-maintainers" if item.get("has_waiting_linked_pr") else "",
             })
 
     print(f"Debug CSV written to {output_path}")

--- a/.github/actions/identify-follow-up-issues/test_identify_follow_up_issues.py
+++ b/.github/actions/identify-follow-up-issues/test_identify_follow_up_issues.py
@@ -1,0 +1,167 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("identify_follow_up_issues.py")
+SPEC = importlib.util.spec_from_file_location("identify_follow_up_issues", MODULE_PATH)
+identify_follow_up_issues = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(identify_follow_up_issues)
+
+
+class LinkedPullRequestTests(unittest.TestCase):
+    def test_only_open_labeled_linked_prs_suppress_an_issue(self):
+        content = {
+            "closedByPullRequestsReferences": {
+                "nodes": [
+                    {
+                        "url": "https://github.com/NVIDIA-NeMo/NeMo/pull/1",
+                        "state": "OPEN",
+                        "labels": {"nodes": [{"name": "waiting-on-maintainers"}]},
+                    },
+                    {
+                        "url": "https://github.com/NVIDIA-NeMo/NeMo/pull/2",
+                        "state": "OPEN",
+                        "labels": {"nodes": [{"name": "waiting-on-customer"}]},
+                    },
+                    {
+                        "url": "https://github.com/NVIDIA-NeMo/NeMo/pull/3",
+                        "state": "MERGED",
+                        "labels": {"nodes": [{"name": "waiting-on-maintainers"}]},
+                    },
+                ]
+            }
+        }
+
+        self.assertEqual(
+            identify_follow_up_issues._get_waiting_linked_pr_urls(content),
+            ["https://github.com/NVIDIA-NeMo/NeMo/pull/1"],
+        )
+
+    @mock.patch.object(identify_follow_up_issues, "remove_label_from_issue", return_value=True)
+    @mock.patch.object(identify_follow_up_issues, "add_label_to_issue", return_value=True)
+    @mock.patch.object(identify_follow_up_issues, "ensure_label_exists", return_value=True)
+    def test_existing_issue_label_is_removed_while_pr_label_is_retained(
+        self, ensure_label_exists, add_label, remove_label
+    ):
+        common = {
+            "repo_name": "NeMo",
+            "has_deprecated_label": False,
+            "has_waiting_on_customer_label": False,
+            "target_branch": "main",
+            "is_draft": False,
+            "classification": "waiting-on-maintainers",
+        }
+        issue = {
+            **common,
+            "item_type": "Issue",
+            "issue_id": 10,
+            "has_maintainers_label": True,
+            "needs_attention": False,
+        }
+        pull_request = {
+            **common,
+            "item_type": "PullRequest",
+            "issue_id": 11,
+            "has_maintainers_label": True,
+            "needs_attention": True,
+        }
+
+        identify_follow_up_issues.update_labels([issue, pull_request], "NVIDIA-NeMo", "token")
+
+        remove_label.assert_called_once_with(
+            "NVIDIA-NeMo", "NeMo", 10, "waiting-on-maintainers", "token"
+        )
+        ensure_label_exists.assert_not_called()
+        add_label.assert_not_called()
+
+
+class FollowUpDecisionTests(unittest.TestCase):
+    NOW = datetime(2026, 8, 14, 12, tzinfo=timezone.utc)
+    STALE = "2026-08-11T12:00:00Z"
+
+    def determine(self, **overrides):
+        values = {
+            "item_type": "Issue",
+            "repo_name": "NeMo",
+            "classification": "waiting-on-maintainers",
+            "last_comment_date": self.STALE,
+            "now": self.NOW,
+        }
+        values.update(overrides)
+        return identify_follow_up_issues._determine_needs_attention(**values)
+
+    def test_stale_issue_without_waiting_linked_pr_needs_attention(self):
+        self.assertEqual(self.determine(), (True, True, False))
+
+    def test_waiting_linked_pr_suppresses_stale_issue(self):
+        self.assertEqual(self.determine(has_waiting_linked_pr=True), (False, True, False))
+
+    def test_non_megatron_stale_approval_keeps_existing_override(self):
+        self.assertEqual(
+            self.determine(
+                item_type="PullRequest",
+                classification="waiting-on-author",
+                last_approval_date=self.STALE,
+                all_reviewers_approved=True,
+            ),
+            (True, True, True),
+        )
+
+    def test_megatron_stale_approval_with_approved_label_uses_override(self):
+        self.assertEqual(
+            self.determine(
+                item_type="PullRequest",
+                repo_name="Megatron-LM",
+                classification="waiting-on-author",
+                last_approval_date=self.STALE,
+                all_reviewers_approved=True,
+                has_approved_label=True,
+            ),
+            (True, True, True),
+        )
+
+    def test_megatron_stale_approval_without_approved_label_uses_classification(self):
+        self.assertEqual(
+            self.determine(
+                item_type="PullRequest",
+                repo_name="Megatron-LM",
+                classification="waiting-on-author",
+                last_approval_date=self.STALE,
+                all_reviewers_approved=True,
+                has_approved_label=False,
+            ),
+            (False, True, False),
+        )
+
+    def test_megatron_without_approved_label_can_still_follow_normal_stale_rule(self):
+        self.assertEqual(
+            self.determine(
+                item_type="PullRequest",
+                repo_name="Megatron-LM",
+                last_approval_date=self.STALE,
+                all_reviewers_approved=True,
+                has_approved_label=False,
+            ),
+            (True, True, False),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- suppress `waiting-on-maintainers` on issues when an open linked PR already carries the label
- require the exact `Approved` label before applying the stale-approval override to Megatron-LM PRs
- add bounded linked-PR GraphQL data, truncation diagnostics, debug output, and focused unit coverage

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python -m unittest discover -s .github/actions/identify-follow-up-issues -p 'test_*.py' -v` (8 passed)
- `git diff --check`
- read-only old/current dry-run comparison on the same 867-item snapshot and replayed classifications
  - 23 duplicate issue labels planned for removal
  - 9 Megatron-LM PRs correctly fall back from the approval override because they lack `Approved`
  - no GitHub label mutations performed
- GraphQL bounds audit: max 3 linked PRs, max 7 labels, zero truncation warnings
