### PR TITLE
fix: remove duplicated 0.70.1 bug-fix entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -473,7 +473,6 @@
 ### Bug Fixes
 
 * Make build-test-publish workflow compatible with MBridge ([#367](https://github.com/NVIDIA-NeMo/FW-CI-templates/issues/367)) ([a68897d](https://github.com/NVIDIA-NeMo/FW-CI-templates/commit/a68897d289c64569d344d54e5ffdd8c880be08c8))
-* Make build-test-publish workflow compatible with MBridge ([#367](https://github.com/NVIDIA-NeMo/FW-CI-templates/issues/367)) ([a68897d](https://github.com/NVIDIA-NeMo/FW-CI-templates/commit/a68897d289c64569d344d54e5ffdd8c880be08c8))
 
 ## [0.70.0](https://github.com/NVIDIA-NeMo/FW-CI-templates/compare/v0.69.1...v0.70.0) (2026-01-30)
 


### PR DESCRIPTION
This PR addresses the following issue in `CHANGELOG.md`: remove duplicated 0.70.1 bug-fix entry.

## Changes
- `CHANGELOG.md`: remove duplicated 0.70.1 bug-fix entry.

## Details
```diff
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
-## [0.70.1](https://github.com/NVIDIA-NeMo/FW-CI-templates/compare/v0.70.0...v0.70.1) (2026-02-04)
-
-
-### Bug Fixes
-
-* Make build-test-publish workflow compatible with MBridge ([#367](https://github.com/NVIDIA-NeMo/FW-CI-templates/issues/367)) ([a68897d](https://github.com/NVIDIA-NeMo/FW-CI-templates/commit/a68897d289c64569d344d54e5ffdd8c880be08c8))
-* Make build-test-publish workflow compatible with MBridge ([#367](https://github.com/NVIDIA-NeMo/FW-CI-templates/issues/367)) ([a68897d](https://github.com/NVIDIA-NeMo/FW-CI-templates/commit/a68897d289c64569d344d54e5ffdd8c880be08c8))
-
-## [0.70.0](https://github.com/NVIDIA-NeMo/FW-CI-templates/compare/v0.69.1...v0.70.0) (2026-01-30)
+## [0.70.1](https://github.com/NVIDIA-NeMo/FW-CI-templates/compare/v0.70.0...v0.70.1) (2026-02-04)
+
+
+### Bug Fixes
+
+* Make build-test-publish workflow compatible with MBridge ([#367](https://github.com/NVIDIA-NeMo/FW-CI-templates/issues/367)) ([a68897d](https://github.com/NVIDIA-NeMo/FW-CI-templates/commit/a68897d289c64569d344d54e5ffdd8c880be08c8))
+
+## [0.70.0](https://github.com/NVIDIA-NeMo/FW-CI-templates/compare/v0.69.1...v0.70.0) (2026-01-30)
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).