### PR TITLE
fix: correct typo 'Regrex' to 'Regex' in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1163,7 +1163,7 @@
 
 ### Bug Fixes
 
-* Regrex parser of cherry-pick automation ([#129](https://github.com/NVIDIA/NeMo-FW-CI-templates/issues/129)) ([3bb3dc1](https://github.com/NVIDIA/NeMo-FW-CI-templates/commit/3bb3dc1b9c595bada0b1fb13119cabf17d555cdd))
+* Regex parser of cherry-pick automation ([#129](https://github.com/NVIDIA/NeMo-FW-CI-templates/issues/129)) ([3bb3dc1](https://github.com/NVIDIA/NeMo-FW-CI-templates/commit/3bb3dc1b9c595bada0b1fb13119cabf17d555cdd))
 
 ## [0.22.6](https://github.com/NVIDIA/NeMo-FW-CI-templates/compare/v0.22.5...v0.22.6) (2025-02-19)
 


### PR DESCRIPTION
This PR fixes a typo in `CHANGELOG.md`: correct typo 'Regrex' to 'Regex' in changelog.

## Changes
- `CHANGELOG.md`: correct typo 'Regrex' to 'Regex' in changelog.

## Details
```diff
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-* Regrex parser of cherry-pick automation ([#129](https://github.com/NVIDIA/NeMo-FW-CI-templates/issues/129)) ([3bb3dc1](https://github.com/NVIDIA/NeMo-FW-CI-templates/commit/3bb3dc1b9c595bada0b1fb13119cabf17d555cdd))
+* Regex parser of cherry-pick automation ([#129](https://github.com/NVIDIA/NeMo-FW-CI-templates/issues/129)) ([3bb3dc1](https://github.com/NVIDIA/NeMo-FW-CI-templates/commit/3bb3dc1b9c595bada0b1fb13119cabf17d555cdd))
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).