### PR TITLE
fix: correct typo 'boostrap' to 'bootstrap' in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,7 +353,7 @@
 
 ### Bug Fixes
 
-* Set boostrap-sha ([#411](https://github.com/NVIDIA-NeMo/FW-CI-templates/issues/411)) ([3a95d55](https://github.com/NVIDIA-NeMo/FW-CI-templates/commit/3a95d55176bd0a0a2e5e1ad5e4432d3964091c2b))
+* Set bootstrap-sha ([#411](https://github.com/NVIDIA-NeMo/FW-CI-templates/issues/411)) ([3a95d55](https://github.com/NVIDIA-NeMo/FW-CI-templates/commit/3a95d55176bd0a0a2e5e1ad5e4432d3964091c2b))
 
 ## [0.79.0](https://github.com/NVIDIA-NeMo/FW-CI-templates/compare/v0.78.1...v0.79.0) (2026-03-13)
 


### PR DESCRIPTION
This PR fixes a typo in `CHANGELOG.md`: correct typo 'boostrap' to 'bootstrap' in changelog.

## Changes
- `CHANGELOG.md`: correct typo 'boostrap' to 'bootstrap' in changelog.

## Details
```diff
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-* Set boostrap-sha ([#411](https://github.com/NVIDIA-NeMo/FW-CI-templates/issues/411)) ([3a95d55](https://github.com/NVIDIA-NeMo/FW-CI-templates/commit/3a95d55176bd0a0a2e5e1ad5e4432d3964091c2b))
+* Set bootstrap-sha ([#411](https://github.com/NVIDIA-NeMo/FW-CI-templates/issues/411)) ([3a95d55](https://github.com/NVIDIA-NeMo/FW-CI-templates/commit/3a95d55176bd0a0a2e5e1ad5e4432d3964091c2b))
```

## Tests

> Let me know if you want tests added for this fix or not.

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).