### PR TITLE
feat: prepare docs metadata before release tags

### DIFF
--- a/.github/workflows/_fern_docs_publish.yml
+++ b/.github/workflows/_fern_docs_publish.yml
@@ -46,6 +46,14 @@ on:
         required: false
         type: string
         default: fern
+      docs-version:
+        description: |
+          Release version to stamp into the `slug: latest` Fern picker entry
+          before publishing. The surrounding display-name text is preserved.
+          Leave empty to publish docs.yml unchanged.
+        required: false
+        type: string
+        default: ''
       container-image:
         description: |
           Optional container image to run the job in, such as
@@ -66,6 +74,54 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Stamp release version in Fern picker
+        if: inputs.docs-version != ''
+        env:
+          DOCS_VERSION: ${{ inputs.docs-version }}
+          DOCS_YML: ${{ inputs.fern-directory }}/docs.yml
+        run: |
+          VERSION="${DOCS_VERSION#v}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::Invalid Fern docs version: '$DOCS_VERSION'"
+            exit 1
+          fi
+
+          if [[ ! -f "$DOCS_YML" ]]; then
+            echo "::error::Fern docs configuration not found: $DOCS_YML"
+            exit 1
+          fi
+
+          latest_count=$(yq '[.versions[] | select(.slug == "latest")] | length' "$DOCS_YML")
+          if [[ "$latest_count" != "1" ]]; then
+            echo "::error::$DOCS_YML must contain exactly one version with slug 'latest'"
+            exit 1
+          fi
+
+          current_display=$(yq -r '.versions[] | select(.slug == "latest") | .display-name' "$DOCS_YML")
+          if [[ "$current_display" =~ v?[0-9]+\.[0-9]+\.[0-9]+([A-Za-z0-9.-]+)? ]]; then
+            current_version="${BASH_REMATCH[0]}"
+            if [[ "$current_version" == v* ]]; then
+              stamped_version="v$VERSION"
+            else
+              stamped_version="$VERSION"
+            fi
+            latest_display="${current_display/$current_version/$stamped_version}"
+          else
+            latest_display="$current_display · $VERSION"
+          fi
+
+          export latest_display
+          yq -i \
+            '(.versions[] | select(.slug == "latest") | .display-name) = strenv(latest_display)' \
+            "$DOCS_YML"
+
+          actual_display=$(yq -r '.versions[] | select(.slug == "latest") | .display-name' "$DOCS_YML")
+          if [[ "$actual_display" != "$latest_display" ]]; then
+            echo "::error::Failed to stamp release version in $DOCS_YML"
+            exit 1
+          fi
+          echo "Fern latest picker: $current_display -> $actual_display"
 
       - name: Setup Node.js
         if: ${{ inputs.container-image == '' }}

--- a/.github/workflows/_release_bump.yml
+++ b/.github/workflows/_release_bump.yml
@@ -95,6 +95,26 @@ on:
         required: false
         default: "./"
         description: Sub-directory containing the package source(s).
+      prepare-release-docs:
+        type: boolean
+        required: false
+        default: false
+        description: Prepare the standard Sphinx release metadata before creating the next-version bump commit.
+      docs-version-directory:
+        type: string
+        required: false
+        default: "docs"
+        description: Repo-relative directory containing conf.py, project.json, and versions1.json.
+      docs-target-path:
+        type: string
+        required: false
+        default: ""
+        description: Public docs.nvidia.com path used to construct the version-picker URL.
+      publish-as-latest:
+        type: boolean
+        required: false
+        default: true
+        description: Mark the prepared stable release as the preferred docs version.
     secrets:
       BOT_KEY:
         required: true
@@ -102,6 +122,9 @@ on:
       release-version:
         description: The version being released (current version of the first bump target, before the bump).
         value: ${{ jobs.bump-next-version.outputs.release-version }}
+      prepared-release-ref:
+        description: Commit SHA containing release docs metadata but not the next-version package bump.
+        value: ${{ jobs.bump-next-version.outputs.prepared-release-ref }}
 
 permissions:
   contents: write
@@ -152,6 +175,7 @@ jobs:
     outputs:
       release-version: ${{ steps.bump.outputs.release-version }}
       next-version: ${{ steps.bump.outputs.next-version }}
+      prepared-release-ref: ${{ steps.prepared-release-ref.outputs.value }}
     env:
       IS_INERT: ${{ inputs.validate-only || inputs.dry-run }}
       PACKAGING: ${{ inputs.packaging }}
@@ -249,6 +273,100 @@ jobs:
           echo "next-version=$NEXT_VERSION" | tee -a "$GITHUB_OUTPUT"
           printf '%s\n' "${BUMPED_FILES[@]}" > /tmp/bumped-files.txt
 
+      - name: Prepare release docs metadata
+        if: inputs.prepare-release-docs == true
+        env:
+          DOCS_DIR: ${{ inputs.docs-version-directory }}
+          DOCS_TARGET_PATH: ${{ inputs.docs-target-path }}
+          PUBLISH_AS_LATEST: ${{ inputs.publish-as-latest }}
+          VERSION: ${{ steps.bump.outputs.release-version }}
+        run: |
+          cd ${{ github.run_id }}
+
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([A-Za-z0-9.-]+)?$ ]]; then
+            echo "::error::Invalid release version for docs metadata: '$VERSION'"
+            exit 1
+          fi
+
+          DOCS_DIR="${DOCS_DIR%/}"
+          DOCS_TARGET_PATH="${DOCS_TARGET_PATH#/}"
+          DOCS_TARGET_PATH="${DOCS_TARGET_PATH%/}"
+          if [[ -z "$DOCS_DIR" || -z "$DOCS_TARGET_PATH" ]]; then
+            echo "::error::docs-version-directory and docs-target-path are required when prepare-release-docs is enabled"
+            exit 1
+          fi
+
+          CONF_FILE="$DOCS_DIR/conf.py"
+          PROJECT_FILE="$DOCS_DIR/project.json"
+          PICKER_FILE="$DOCS_DIR/versions1.json"
+          for file in "$CONF_FILE" "$PROJECT_FILE" "$PICKER_FILE"; do
+            if [[ ! -f "$file" ]]; then
+              echo "::error::Required release docs metadata file not found: $file"
+              exit 1
+            fi
+          done
+
+          if ! grep -qE "^release = [\"'].*[\"']$" "$CONF_FILE"; then
+            echo "::error::$CONF_FILE must contain a top-level quoted 'release = ...' assignment"
+            exit 1
+          fi
+          sed -i -E "s/^release = .*/release = \"${VERSION}\"/" "$CONF_FILE"
+
+          tmp_project=$(mktemp)
+          jq --arg version "$VERSION" '.version = $version' "$PROJECT_FILE" > "$tmp_project"
+          mv "$tmp_project" "$PROJECT_FILE"
+
+          public_url="https://docs.nvidia.com/${DOCS_TARGET_PATH}/${VERSION}/"
+          tmp_picker=$(mktemp)
+          jq \
+            --arg version "$VERSION" \
+            --arg url "$public_url" \
+            --argjson latest "$PUBLISH_AS_LATEST" \
+            '
+              def clear_latest:
+                del(.preferred)
+                | if ((.name? | type) == "string")
+                  then .name |= sub(" \\(latest\\)$"; "")
+                  else .
+                  end;
+
+              map(
+                if .version == $version then empty
+                elif $latest and (.preferred? == true) then clear_latest
+                else .
+                end
+              ) as $remaining
+              | ({
+                  name: ($version + (if $latest then " (latest)" else "" end)),
+                  version: $version,
+                  url: $url
+                } + (if $latest then {preferred: true} else {} end)) as $release
+              | if (($remaining | length) > 0 and $remaining[0].version == "nightly")
+                then [$remaining[0], $release] + $remaining[1:]
+                else [$release] + $remaining
+                end
+            ' "$PICKER_FILE" > "$tmp_picker"
+          mv "$tmp_picker" "$PICKER_FILE"
+
+          if [[ "$(jq -r '.version' "$PROJECT_FILE")" != "$VERSION" ]]; then
+            echo "::error::$PROJECT_FILE does not identify release $VERSION"
+            exit 1
+          fi
+          if [[ "$(jq --arg version "$VERSION" '[.[] | select(.version == $version)] | length' "$PICKER_FILE")" != "1" ]]; then
+            echo "::error::$PICKER_FILE must contain release $VERSION exactly once"
+            exit 1
+          fi
+          if [[ "$PUBLISH_AS_LATEST" == "true" ]]; then
+            preferred_version=$(jq -r '[.[] | select(.preferred == true) | .version] | if length == 1 then .[0] else "" end' "$PICKER_FILE")
+            if [[ "$preferred_version" != "$VERSION" ]]; then
+              echo "::error::$PICKER_FILE must contain exactly one preferred entry for $VERSION"
+              exit 1
+            fi
+          fi
+
+          printf '%s\n' "$CONF_FILE" "$PROJECT_FILE" "$PICKER_FILE" > /tmp/prepared-docs-files.txt
+          git diff --check -- "$CONF_FILE" "$PROJECT_FILE" "$PICKER_FILE"
+
       - name: Record computed versions
         if: env.IS_INERT == 'true'
         run: |
@@ -257,6 +375,9 @@ jobs:
             echo
             echo "- release-version (current): \`${{ steps.bump.outputs.release-version }}\`"
             echo "- next-version (after bump): \`${{ steps.bump.outputs.next-version }}\`"
+            if [[ "${{ inputs.prepare-release-docs }}" == "true" ]]; then
+              echo "- release docs metadata: prepared and validated locally"
+            fi
             echo
             echo "IS_INERT=true → preconditions are asserted (App permissions +"
             echo "source rule \`isAdminEnforced=false\`). No commit is pushed, no PR"
@@ -363,18 +484,34 @@ jobs:
           echo "VERSION_BUMP_BRANCH=$BRANCH" | tee -a $GITHUB_ENV
 
       - name: Create and push deployment branch
+        id: deployment-branch
         if: env.IS_INERT == 'false'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           cd ${{ github.run_id }}
-          cd ${{ inputs.root-dir }}
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           TMP_BRANCH="deploy-release/$(uuidgen)"
           git checkout -b "$TMP_BRANCH"
+
+          # Commit release docs metadata separately so the release tag can point
+          # here while the target branch continues to the next package version.
+          if [[ -s /tmp/prepared-docs-files.txt ]]; then
+            while IFS= read -r f; do
+              [[ -n "$f" ]] && git add -- "$f"
+            done < /tmp/prepared-docs-files.txt
+            if ! git diff --cached --quiet; then
+              git commit -s -m "docs(release): prepare ${{ steps.bump.outputs.release-version }}"
+            fi
+          fi
+
+          PREPARED_RELEASE_REF=$(git rev-parse HEAD)
+          echo "prepared-release-ref=$PREPARED_RELEASE_REF" | tee -a "$GITHUB_OUTPUT"
+
+          cd ${{ inputs.root-dir }}
           while IFS= read -r f; do
             [[ -n "$f" ]] && git add "$f"
           done < /tmp/bumped-files.txt
@@ -390,6 +527,17 @@ jobs:
             --body "This is an automated PR to bump ${{ inputs.library-name }} to v${{ steps.bump.outputs.next-version }}.")
           PR_NUMBER="${PR_URL##*/}"
           echo "PR_NUMBER=$PR_NUMBER" | tee -a $GITHUB_ENV
+
+      - name: Resolve prepared release ref
+        id: prepared-release-ref
+        env:
+          PREPARED_RELEASE_REF: ${{ steps.deployment-branch.outputs.prepared-release-ref }}
+          RELEASE_REF: ${{ inputs.release-ref }}
+        run: |
+          if [[ -z "$PREPARED_RELEASE_REF" ]]; then
+            PREPARED_RELEASE_REF="$RELEASE_REF"
+          fi
+          echo "value=$PREPARED_RELEASE_REF" | tee -a "$GITHUB_OUTPUT"
 
       - name: Merge deploy-release branch into target
         if: env.IS_INERT == 'false'

--- a/.github/workflows/_release_library.yml
+++ b/.github/workflows/_release_library.yml
@@ -224,6 +224,16 @@ on:
         description: Space-separated `--no-extra <name>` flags to skip optional extras when syncing all groups (only used when docs-sync-all is true).
         type: string
         default: ""
+      prepare-release-docs:
+        required: false
+        description: Create a release commit that updates docs/conf.py, docs/project.json, and docs/versions1.json before the next-version bump.
+        type: boolean
+        default: false
+      docs-version-directory:
+        required: false
+        description: Repo-relative directory containing release docs metadata files.
+        type: string
+        default: "docs"
       container-options:
         required: false
         description: Options to pass to the container
@@ -293,6 +303,11 @@ jobs:
             exit 1
           fi
 
+          if [[ "${{ inputs.prepare-release-docs }}" == "true" && "${{ inputs.skip-version-bump }}" == "true" ]]; then
+            echo "::error::prepare-release-docs requires the version-bump job so it can create and publish the prepared release commit"
+            exit 1
+          fi
+
   bump:
     needs: validate-inputs
     uses: ./.github/workflows/_release_bump.yml
@@ -311,6 +326,10 @@ jobs:
       has-src-dir: ${{ inputs.has-src-dir }}
       packaging: ${{ inputs.packaging }}
       root-dir: ${{ inputs.root-dir }}
+      prepare-release-docs: ${{ inputs.prepare-release-docs && inputs.publish-docs }}
+      docs-version-directory: ${{ inputs.docs-version-directory }}
+      docs-target-path: ${{ inputs.docs-target-path }}
+      publish-as-latest: ${{ inputs.publish-as-latest }}
     secrets: inherit
 
   build-test-publish-wheel:
@@ -327,7 +346,7 @@ jobs:
       suppress-failure-notify: ${{ inputs.validate-only }}
       python-package: ${{ inputs.python-package }}
       python-version: ${{ inputs.python-version }}
-      ref: ${{ inputs.release-ref }}
+      ref: ${{ needs.bump.outputs.prepared-release-ref || inputs.release-ref }}
       packaging: ${{ inputs.packaging }}
       has-src-dir: ${{ inputs.has-src-dir }}
       skip-test-wheel: ${{ inputs.skip-test-wheel }}
@@ -351,7 +370,7 @@ jobs:
       )
       && !cancelled()
     with:
-      release-ref: ${{ inputs.release-ref }}
+      release-ref: ${{ needs.bump.outputs.prepared-release-ref || inputs.release-ref }}
       release-version: ${{ needs.bump.outputs.release-version || needs.build-test-publish-wheel.outputs.version }}
       library-name: ${{ inputs.library-name }}
       pypi-name: ${{ needs.build-test-publish-wheel.outputs.pypi-name }}


### PR DESCRIPTION
## Background

Release tags can contain stale documentation metadata even when the package version is correct. This caused Megatron-Bridge `v0.5.1` to publish docs identified as `0.5.0` and Megatron-LM `core_v0.18.2` to publish docs identified as `0.18.0`.

The release workflow computes the release version and commits the next package version, but it does not prepare `docs/conf.py`, `docs/project.json`, or `docs/versions1.json` for each patch release.

Closes #553.

## What changed

- Add opt-in `prepare-release-docs` and `docs-version-directory` inputs to `_release_library.yml`.
- Add optional `docs-version` stamping to `_fern_docs_publish.yml`; it updates the single `slug: latest` picker label while preserving surrounding text.
- Update and validate the three standard Sphinx release metadata files.
- Create a separate signed `docs(release)` commit before the existing next-version commit.
- Expose the prepared SHA and use it for wheel build, GitHub tag/release, and docs build.
- Reject the unsupported combination of docs preparation with `skip-version-bump`.

Existing consumers retain their current behavior until they enable `prepare-release-docs`.

## Details

```mermaid
flowchart LR
    A[Pinned release SHA] --> B[Compute release and next versions]
    B --> C[Prepare docs metadata]
    C --> D[Signed docs release commit]
    D --> E[Prepared release SHA]
    E --> F[Build and publish wheel]
    E --> G[Create GitHub tag and release]
    E --> H[Build and publish docs]
    D --> I[Commit next package version]
```

The picker update is idempotent. When `publish-as-latest` is true, the new version is the only preferred entry. When false, the existing preferred version is preserved.

## Tested

- `git diff --check`
- `actionlint -ignore 'SC2004:' -ignore 'SC2086:' -ignore 'SC2016:' .github/workflows/_release_bump.yml .github/workflows/_release_library.yml` — no new findings; ignored codes are existing findings in untouched shell blocks.
- `ruby -ryaml -e 'ARGV.each { |file| YAML.load_file(file) }' .github/workflows/_release_bump.yml .github/workflows/_release_library.yml` — parsed successfully.
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest -q .github/actions/identify-follow-up-issues/test_identify_follow_up_issues.py` — 8 passed.
- Executed the exact embedded preparation block against Megatron-Bridge `v0.5.1`: `conf.py`, `project.json`, and the sole preferred picker entry became `0.5.1`.
- Executed it twice against Megatron-LM `core_v0.18.2`: both runs produced digest `605ab567366e500d78d02bb9f385de38e2a2990df922bbdd8fd836c0c9ddef7a`; release metadata became `0.18.2`.
- Simulated commit ordering: prepared commit retained package/docs `0.5.1`; its child retained docs `0.5.1` and bumped the package to `0.5.2`.


- Initial CI runs: [secrets-detector 32136391383](https://github.com/NVIDIA-NeMo/FW-CI-templates/actions/runs/32136391383), [pre-flight 32136391401](https://github.com/NVIDIA-NeMo/FW-CI-templates/actions/runs/32136391401), [semantic checks 32136391458](https://github.com/NVIDIA-NeMo/FW-CI-templates/actions/runs/32136391458) and [32136391505](https://github.com/NVIDIA-NeMo/FW-CI-templates/actions/runs/32136391505).


- [Megatron-Bridge companion PR #5641](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/5641): [dry-run 32137007085](https://github.com/NVIDIA-NeMo/Megatron-Bridge/actions/runs/32137007085) completed `success`; bump job 95710720969 resolved and validated stale patch docs as `0.5.1`, and all wheel/finalize/docs jobs succeeded.
- [Megatron-LM companion PR #6621](https://github.com/NVIDIA/Megatron-LM/pull/6621): [dry-run 32137179908](https://github.com/NVIDIA/Megatron-LM/actions/runs/32137179908) completed `success`; bump job 95711180977 resolved and validated stale patch docs as `0.18.2`, and all wheel/finalize/docs jobs succeeded.
- Dry-run limitation: branch pushes and signed docs commits were intentionally skipped by `IS_INERT`; the non-inert commit ordering and idempotence are covered by the local simulations above.


- Executed the exact embedded Fern stamp against Bridge, Curator, and AutoModel picker formats; verified expected labels, two-pass idempotence, invalid-version rejection, and missing-`latest` rejection.
